### PR TITLE
feat(runtime): add gamescope headless isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Chinese documentation: [docs/README.zh-CN.md](./docs/README.zh-CN.md)
 - GNOME Shell 45+ for GNOME window-bridge mode, plus the bundled extension from [contrib/gnome-shell-extension](./contrib/gnome-shell-extension).
 - `gjs` with Gtk 4 support for GNOME native video mode.
 - XWayland/X11 for Wine render window capture.
+- `gamescope` for optional headless display isolation.
 - X11 Composite extension.
 - Vulkan/GL stack usable by `wgpu`.
 - FFmpeg libraries and headers (`libavformat`, `libavcodec`, `libavutil`, `libswscale`).
@@ -33,7 +34,7 @@ Chinese documentation: [docs/README.zh-CN.md](./docs/README.zh-CN.md)
 
 Example packages (Arch Linux):
 ```bash
-sudo pacman -S --needed rustup pkgconf ffmpeg libx11 libxcomposite libxfixes libxdamage libxrender vulkan-icd-loader wine wlr-randr
+sudo pacman -S --needed rustup pkgconf ffmpeg libx11 libxcomposite libxfixes libxdamage libxrender vulkan-icd-loader wine wlr-randr gamescope
 ```
 
 ## Build

--- a/config.example.toml
+++ b/config.example.toml
@@ -8,6 +8,13 @@ fps_report_interval_secs = 1
 hide_debug_window = true
 hidden_workspace_name = "top"
 
+[isolation]
+mode = "none" # none | gamescope_headless
+command = "gamescope"
+# width = 2560
+# height = 1600
+startup_timeout_secs = 10
+
 [gnome]
 extension_dbus_name = "io.github.weLayerd.Gnome"
 

--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,13 @@ refind_window_on_capture_error = true
 show_fps = true
 fps_report_interval_secs = 2
 
+[isolation]
+mode = "gamescope_headless"
+command = "gamescope"
+width = 2560
+height = 1600
+startup_timeout_secs = 10
+
 [wine]
 command = "wine"
 wallpaper_exe = "/home/aromatic/.local/share/Steam/steamapps/common/wallpaper_engine/wallpaper64.exe"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -21,6 +21,19 @@ memory_max = "max"   # optional, e.g. "2147483648"
 cpu_max = "max 100000" # optional, e.g. "50000 100000"
 ```
 
+Hard-isolate the debug window:
+```toml
+[isolation]
+mode = "gamescope_headless" # none | gamescope_headless
+command = "gamescope"
+width = 2560
+height = 1600
+startup_timeout_secs = 10
+```
+- `none`: Wine still creates a host XWayland/Niri window, and `hide_debug_window` moves or hides it.
+- `gamescope_headless`: starts a headless gamescope instance, runs Wine against gamescope's internal XWayland display, and captures XComposite from that internal `DISPLAY`. Niri never sees the Wallpaper Engine window, so switching workspaces or opening overview cannot reveal it.
+- `width`/`height` are optional. When omitted, we-layerd uses `-width` / `-height` from `wine.args`, then falls back to 1920x1080.
+
 Debug window visibility:
 ```toml
 [general]
@@ -32,6 +45,7 @@ hidden_workspace_name = "top"
 - sway: uses scratchpad behavior.
 - niri: target workspace spec; use `top` to move to the top/first workspace.
 For niri, hide flow is `move-window-to-workspace` first, then `move-window-to-floating`.
+When `isolation.mode = "gamescope_headless"` is enabled, host WM hiding is skipped because the real Wine window is no longer in the host window tree.
 
 niri startup sizing:
 - Wallpaper Engine debug window may open as half-screen by default under niri tiling.

--- a/docs/CONFIGURATION.zh-CN.md
+++ b/docs/CONFIGURATION.zh-CN.md
@@ -21,6 +21,19 @@ memory_max = "max"   # 可选，如 "2147483648"
 cpu_max = "max 100000" # 可选，如 "50000 100000"
 ```
 
+硬隔离调试窗口：
+```toml
+[isolation]
+mode = "gamescope_headless" # none | gamescope_headless
+command = "gamescope"
+width = 2560
+height = 1600
+startup_timeout_secs = 10
+```
+- `none`：Wine 窗口仍在宿主 XWayland/Niri 中，`hide_debug_window` 负责移动或隐藏它。
+- `gamescope_headless`：启动一个无窗口 gamescope，Wine 连接 gamescope 内部 XWayland，we-layerd 也从该内部 `DISPLAY` 抓 XComposite。此时 Niri 不会枚举到 Wallpaper Engine 窗口，用户主动切工作区或打开 overview 也看不到它。
+- `width`/`height` 可省略；省略时优先使用 `wine.args` 中的 `-width` / `-height`，再退回到 1920x1080。
+
 调试窗口隐藏配置：
 ```toml
 [general]
@@ -32,6 +45,7 @@ hidden_workspace_name = "top"
 - sway：使用 scratchpad 机制。
 - niri：作为目标工作区标识；`top` 表示最上/第一个工作区。
 在 niri 下隐藏顺序是先 `move-window-to-workspace`，再 `move-window-to-floating`。
+如果启用 `isolation.mode = "gamescope_headless"`，宿主 WM 隐藏逻辑会跳过，因为真实 Wine 窗口已经不在宿主窗口树里。
 
 niri 启动尺寸：
 - niri 的默认平铺行为可能让 Wallpaper Engine 调试窗口初始为半屏。

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,8 @@ use tracing::{info, warn};
 
 use crate::{
     cgroup::RuntimeCgroup,
-    config::{Config, RuntimeMode, RuntimeWallpaperType},
+    config::{Config, IsolationMode, RuntimeMode, RuntimeWallpaperType},
+    display_isolation,
     gnome::{self, RegisteredWindow, ResolvedBackend},
     ipc::{self, ControlCommand, RuntimeLoopExit},
     wayland,
@@ -417,6 +418,9 @@ fn run_runtime_session(
         }
     }
 
+    let mut runtime_cfg = runtime_cfg.clone();
+    let _display_isolation = display_isolation::start_for_config(&mut runtime_cfg)?;
+
     info!(cfg = ?runtime_cfg, ?runtime_cfg.capture, "starting we-layerd run mode");
     ensure_runtime_access()?;
     let wine = WineProcessHandle::spawn(&runtime_cfg.wine)?;
@@ -447,7 +451,7 @@ fn run_runtime_session(
         match window_finder::find_window_for_process(&runtime_cfg.capture, wine_pid)? {
             Some(found) => {
                 info!(window = found.window, scanned = found.scanned_windows, "using X11 window");
-                apply_debug_window_setup(runtime_cfg, debug_visibility, found.window);
+                apply_debug_window_setup(&runtime_cfg, debug_visibility, found.window);
                 if let Some(path) = runtime_cfg.capture.debug_save_frame_png.as_deref() {
                     let frame = capture_xcomposite::capture_single_frame(found.window)?;
                     capture_xcomposite::save_frame_png(&frame, Path::new(path))?;
@@ -470,10 +474,10 @@ fn run_runtime_session(
             }
         };
 
-    let exit = if matches!(gnome::resolve_backend(runtime_cfg), ResolvedBackend::GnomeShell) {
+    let exit = if matches!(gnome::resolve_backend(&runtime_cfg), ResolvedBackend::GnomeShell) {
         let runtime_state = runtime_state.clone();
         gnome::run_window_bridge(
-            runtime_cfg,
+            &runtime_cfg,
             &runtime_cfg.capture,
             capture_window,
             wine_pid,
@@ -701,7 +705,7 @@ fn apply_debug_window_setup(cfg: &Config, debug_visibility: &DebugWindowVisibili
             warn!(error = %err, window, "failed to set debug window mouse passthrough");
         }
     }
-    if debug_visibility.auto_hide {
+    if debug_visibility.auto_hide && cfg.isolation.mode == IsolationMode::None {
         if let Err(err) = debug_visibility.hide() {
             warn!(error = %err, "failed to auto-hide debug window");
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,10 @@
 use std::{
     env,
     path::Path,
-    sync::{mpsc, Arc, Mutex},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc, Arc, Mutex,
+    },
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -28,8 +31,8 @@ pub fn run(config_path: Option<&Path>) -> Result<()> {
     let current_cfg = Arc::new(Mutex::new(cfg.clone()));
     let runtime_cfg_toml = Arc::new(Mutex::new(runtime_cfg.to_toml_pretty()?));
     let runtime_state = Arc::new(Mutex::new(RuntimeState::new(&runtime_cfg)));
-    let active_wine = Arc::new(Mutex::new(None::<WineProcessHandle>));
-    install_runtime_ctrlc_handler(active_wine.clone())?;
+    let shutdown_requested = Arc::new(AtomicBool::new(false));
+    install_runtime_ctrlc_handler(control_tx.clone(), shutdown_requested.clone())?;
 
     let status_cgroup = runtime_cgroup.clone();
     let status_state = runtime_state.clone();
@@ -142,7 +145,7 @@ pub fn run(config_path: Option<&Path>) -> Result<()> {
             &runtime_cfg,
             &runtime_cgroup,
             &debug_visibility,
-            &active_wine,
+            &shutdown_requested,
             &runtime_state,
             generation,
             &control_rx,
@@ -401,7 +404,7 @@ fn run_runtime_session(
     runtime_cfg: &Config,
     runtime_cgroup: &RuntimeCgroup,
     debug_visibility: &DebugWindowVisibility,
-    active_wine: &Arc<Mutex<Option<WineProcessHandle>>>,
+    shutdown_requested: &AtomicBool,
     runtime_state: &Arc<Mutex<RuntimeState>>,
     generation: u64,
     control_rx: &mpsc::Receiver<ControlCommand>,
@@ -418,14 +421,21 @@ fn run_runtime_session(
         }
     }
 
+    if shutdown_requested.load(Ordering::Relaxed) {
+        return Ok(RuntimeLoopExit::Stop);
+    }
+
     let mut runtime_cfg = runtime_cfg.clone();
     let _display_isolation = display_isolation::start_for_config(&mut runtime_cfg)?;
+    if shutdown_requested.load(Ordering::Relaxed) {
+        return Ok(RuntimeLoopExit::Stop);
+    }
 
     info!(cfg = ?runtime_cfg, ?runtime_cfg.capture, "starting we-layerd run mode");
     ensure_runtime_access()?;
     let wine = WineProcessHandle::spawn(&runtime_cfg.wine)?;
-    if let Ok(mut guard) = active_wine.lock() {
-        *guard = Some(wine.clone());
+    if shutdown_requested.load(Ordering::Relaxed) {
+        return Ok(RuntimeLoopExit::Stop);
     }
 
     let cgroup_on_spawn = runtime_cgroup.clone();
@@ -515,9 +525,6 @@ fn run_runtime_session(
         )?
     };
 
-    if let Ok(mut guard) = active_wine.lock() {
-        *guard = None;
-    }
     Ok(exit)
 }
 
@@ -591,7 +598,9 @@ fn switch_wallpaper(cfg: &Config) -> Result<()> {
 }
 
 fn can_hot_switch_between(current_cfg: &Config, next_cfg: &Config) -> bool {
-    ensure_switchable_runtime(current_cfg).is_ok() && ensure_switchable_runtime(next_cfg).is_ok()
+    ensure_switchable_runtime(current_cfg).is_ok()
+        && ensure_switchable_runtime(next_cfg).is_ok()
+        && current_cfg.isolation == next_cfg.isolation
 }
 
 fn ensure_switchable_runtime(cfg: &Config) -> Result<()> {
@@ -712,17 +721,32 @@ fn apply_debug_window_setup(cfg: &Config, debug_visibility: &DebugWindowVisibili
     }
 }
 
-fn install_runtime_ctrlc_handler(active_wine: Arc<Mutex<Option<WineProcessHandle>>>) -> Result<()> {
-    ctrlc::set_handler(move || {
-        warn!("received Ctrl+C, terminating active runtime");
-        if let Ok(guard) = active_wine.lock() {
-            if let Some(handle) = guard.as_ref() {
-                if let Err(err) = handle.terminate() {
-                    warn!(error = %err, "failed to terminate wine process on Ctrl+C");
-                }
-            }
+fn request_runtime_shutdown(
+    control_tx: &mpsc::Sender<ControlCommand>,
+    shutdown_requested: &AtomicBool,
+) -> Result<bool, mpsc::SendError<ControlCommand>> {
+    if shutdown_requested.swap(true, Ordering::SeqCst) {
+        return Ok(false);
+    }
+
+    control_tx.send(ControlCommand::Stop).map(|()| true)
+}
+
+fn install_runtime_ctrlc_handler(
+    control_tx: mpsc::Sender<ControlCommand>,
+    shutdown_requested: Arc<AtomicBool>,
+) -> Result<()> {
+    ctrlc::set_handler(move || match request_runtime_shutdown(&control_tx, &shutdown_requested) {
+        Ok(true) => {
+            warn!("received Ctrl+C, requesting runtime shutdown");
         }
-        std::process::exit(130);
+        Ok(false) => {
+            warn!("received Ctrl+C while runtime shutdown is already in progress");
+        }
+        Err(_) => {
+            warn!("received Ctrl+C, but runtime control channel is closed");
+            std::process::exit(130);
+        }
     })
     .context("failed to register Ctrl+C handler")
 }
@@ -730,9 +754,15 @@ fn install_runtime_ctrlc_handler(active_wine: Arc<Mutex<Option<WineProcessHandle
 #[cfg(test)]
 mod tests {
     use super::{
-        can_hot_switch_between, RuntimeMode, RuntimePhase, RuntimeState, RuntimeWallpaperType,
+        can_hot_switch_between, request_runtime_shutdown, RuntimeMode, RuntimePhase, RuntimeState,
+        RuntimeWallpaperType,
     };
-    use crate::config::{Config, RuntimeConfig};
+    use std::sync::atomic::AtomicBool;
+
+    use crate::{
+        config::{Config, IsolationMode, RuntimeConfig},
+        ipc::ControlCommand,
+    };
 
     #[test]
     fn hot_switch_requires_window_runtime_on_both_sides() {
@@ -757,6 +787,31 @@ mod tests {
     }
 
     #[test]
+    fn hot_switch_rejects_isolation_boundary_changes() {
+        let current = switchable_scene_config();
+        let mut next = current.clone();
+        next.isolation.mode = IsolationMode::GamescopeHeadless;
+        assert!(!can_hot_switch_between(&current, &next));
+
+        let mut next = current.clone();
+        next.isolation.mode = IsolationMode::GamescopeHeadless;
+        next.isolation.width = Some(2560);
+        assert!(!can_hot_switch_between(&current, &next));
+    }
+
+    #[test]
+    fn ctrlc_request_sends_single_stop() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let requested = AtomicBool::new(false);
+
+        assert_eq!(request_runtime_shutdown(&tx, &requested), Ok(true));
+        assert_eq!(request_runtime_shutdown(&tx, &requested), Ok(false));
+
+        assert_eq!(rx.try_recv().expect("stop command"), ControlCommand::Stop);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
     fn stale_generation_does_not_override_current_phase() {
         let cfg = Config::default();
         let mut state = RuntimeState::new(&cfg);
@@ -768,5 +823,16 @@ mod tests {
 
         assert_eq!(state.generation, current_generation);
         assert_eq!(state.phase, RuntimePhase::Starting);
+    }
+
+    fn switchable_scene_config() -> Config {
+        Config {
+            runtime: Some(RuntimeConfig {
+                mode: RuntimeMode::WineLayerd,
+                wallpaper_type: RuntimeWallpaperType::Scene,
+                video_file: None,
+            }),
+            ..Config::default()
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,7 +91,7 @@ pub enum WineCommandMode {
     CommandOnly,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct IsolationConfig {
     #[serde(default)]
     pub mode: IsolationMode,

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,8 @@ pub struct Config {
     pub runtime: Option<RuntimeConfig>,
     #[serde(default)]
     pub cgroup: CgroupConfig,
+    #[serde(default)]
+    pub isolation: IsolationConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -87,6 +89,28 @@ pub enum WineCommandMode {
     #[default]
     ExeWithArgs,
     CommandOnly,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IsolationConfig {
+    #[serde(default)]
+    pub mode: IsolationMode,
+    #[serde(default = "default_isolation_command")]
+    pub command: String,
+    #[serde(default)]
+    pub width: Option<u32>,
+    #[serde(default)]
+    pub height: Option<u32>,
+    #[serde(default = "default_isolation_startup_timeout_secs")]
+    pub startup_timeout_secs: u64,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum IsolationMode {
+    #[default]
+    None,
+    GamescopeHeadless,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -163,6 +187,14 @@ fn default_wine_cmd() -> String {
     "wine".to_string()
 }
 
+fn default_isolation_command() -> String {
+    "gamescope".to_string()
+}
+
+fn default_isolation_startup_timeout_secs() -> u64 {
+    10
+}
+
 fn default_restart_wine() -> bool {
     true
 }
@@ -218,6 +250,18 @@ impl Default for WineConfig {
     }
 }
 
+impl Default for IsolationConfig {
+    fn default() -> Self {
+        Self {
+            mode: IsolationMode::None,
+            command: default_isolation_command(),
+            width: None,
+            height: None,
+            startup_timeout_secs: default_isolation_startup_timeout_secs(),
+        }
+    }
+}
+
 impl Default for CaptureConfig {
     fn default() -> Self {
         Self {
@@ -256,11 +300,27 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
-    use super::Config;
+    use super::{Config, IsolationMode};
 
     #[test]
     fn default_config_has_expected_fps() {
         let cfg = Config::default();
         assert_eq!(cfg.general.fps_limit, 30);
+    }
+
+    #[test]
+    fn isolation_config_accepts_gamescope_headless() {
+        let raw = r#"
+            [isolation]
+            mode = "gamescope_headless"
+            width = 2560
+            height = 1600
+        "#;
+
+        let cfg: Config = toml::from_str(raw).expect("valid isolation config");
+
+        assert_eq!(cfg.isolation.mode, IsolationMode::GamescopeHeadless);
+        assert_eq!(cfg.isolation.width, Some(2560));
+        assert_eq!(cfg.isolation.height, Some(1600));
     }
 }

--- a/src/display_isolation.rs
+++ b/src/display_isolation.rs
@@ -1,0 +1,276 @@
+use std::{
+    env,
+    ffi::OsString,
+    fs, io,
+    os::unix::process::CommandExt,
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{anyhow, Context, Result};
+use tracing::{info, warn};
+
+use crate::config::{Config, IsolationConfig, IsolationMode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DisplaySize {
+    width: u32,
+    height: u32,
+}
+
+const DEFAULT_WIDTH: u32 = 1920;
+const DEFAULT_HEIGHT: u32 = 1080;
+
+fn resolve_display_size(config: &IsolationConfig, wine_args: &[String]) -> DisplaySize {
+    DisplaySize {
+        width: config.width.or_else(|| numeric_arg(wine_args, "-width")).unwrap_or(DEFAULT_WIDTH),
+        height: config
+            .height
+            .or_else(|| numeric_arg(wine_args, "-height"))
+            .unwrap_or(DEFAULT_HEIGHT),
+    }
+}
+
+struct DisplayEnvGuard {
+    previous: Option<OsString>,
+}
+
+impl DisplayEnvGuard {
+    fn set(display: &str) -> Self {
+        let previous = env::var_os("DISPLAY");
+        env::set_var("DISPLAY", display);
+        Self { previous }
+    }
+}
+
+impl Drop for DisplayEnvGuard {
+    fn drop(&mut self) {
+        match self.previous.as_ref() {
+            Some(value) => env::set_var("DISPLAY", value),
+            None => env::remove_var("DISPLAY"),
+        }
+    }
+}
+
+pub struct DisplayIsolation {
+    child: Option<Child>,
+    _env_guard: DisplayEnvGuard,
+    pgid: i32,
+    display_file: PathBuf,
+}
+
+pub fn start_for_config(config: &mut Config) -> Result<Option<DisplayIsolation>> {
+    if config.isolation.mode == IsolationMode::None {
+        return Ok(None);
+    }
+
+    let isolated = start_gamescope_headless(&config.isolation, &config.wine.args)?;
+    config.wine.env.insert("DISPLAY".to_string(), isolated.display.clone());
+    let env_guard = DisplayEnvGuard::set(&isolated.display);
+
+    Ok(Some(DisplayIsolation {
+        child: Some(isolated.child),
+        _env_guard: env_guard,
+        pgid: isolated.pgid,
+        display_file: isolated.display_file,
+    }))
+}
+
+struct StartedDisplay {
+    display: String,
+    child: Child,
+    pgid: i32,
+    display_file: PathBuf,
+}
+
+fn start_gamescope_headless(
+    config: &IsolationConfig,
+    wine_args: &[String],
+) -> Result<StartedDisplay> {
+    let size = resolve_display_size(config, wine_args);
+    let display_file = next_display_file()?;
+    let display_file_str = display_file.to_string_lossy().to_string();
+    let args = gamescope_headless_args(&size, &display_file_str);
+
+    let _ = fs::remove_file(&display_file);
+    let mut cmd = Command::new(&config.command);
+    cmd.args(&args).stdout(Stdio::inherit()).stderr(Stdio::inherit());
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setpgid(0, 0) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let mut child = cmd
+        .spawn()
+        .with_context(|| format!("failed to spawn isolated display '{}'", config.command))?;
+    let pgid = child.id() as i32;
+    let timeout = Duration::from_secs(config.startup_timeout_secs.max(1));
+    let x_display_value = match wait_for_display(&mut child, &display_file, timeout) {
+        Ok(display) => display,
+        Err(err) => {
+            let _ = terminate_process_group(pgid);
+            let _ = child.wait();
+            let _ = fs::remove_file(&display_file);
+            return Err(err);
+        }
+    };
+    info!(
+        pid = child.id(),
+        pgid,
+        x_display = %x_display_value,
+        width = size.width,
+        height = size.height,
+        "started gamescope headless isolated display"
+    );
+
+    Ok(StartedDisplay { display: x_display_value, child, pgid, display_file })
+}
+
+fn gamescope_headless_args(size: &DisplaySize, display_file: &str) -> Vec<String> {
+    vec![
+        "--backend".to_string(),
+        "headless".to_string(),
+        "-W".to_string(),
+        size.width.to_string(),
+        "-H".to_string(),
+        size.height.to_string(),
+        "-w".to_string(),
+        size.width.to_string(),
+        "-h".to_string(),
+        size.height.to_string(),
+        "--xwayland-count".to_string(),
+        "1".to_string(),
+        "--".to_string(),
+        "/bin/sh".to_string(),
+        "-c".to_string(),
+        "printf '%s\n' \"$DISPLAY\" > \"$1\"; exec sleep infinity".to_string(),
+        "we-layerd-gamescope-display".to_string(),
+        display_file.to_string(),
+    ]
+}
+
+fn next_display_file() -> Result<PathBuf> {
+    let runtime_dir = env::var_os("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow!("XDG_RUNTIME_DIR is not set for display isolation"))?;
+    let dir = runtime_dir.join("we-layerd");
+    fs::create_dir_all(&dir)
+        .with_context(|| format!("failed to create runtime directory {}", dir.display()))?;
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before UNIX_EPOCH")?
+        .as_nanos();
+    Ok(dir.join(format!("gamescope-display-{}-{nanos}.txt", std::process::id())))
+}
+
+fn wait_for_display(child: &mut Child, display_file: &Path, timeout: Duration) -> Result<String> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Some(status) = child.try_wait().context("failed to poll isolated display process")? {
+            return Err(anyhow!("isolated display exited before publishing DISPLAY: {status:?}"));
+        }
+
+        if let Ok(raw) = fs::read_to_string(display_file) {
+            let display = raw.trim().to_string();
+            if !display.is_empty() {
+                return Ok(display);
+            }
+        }
+
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    Err(anyhow!("timed out waiting for isolated display DISPLAY file: {}", display_file.display()))
+}
+
+impl Drop for DisplayIsolation {
+    fn drop(&mut self) {
+        if let Err(err) = terminate_process_group(self.pgid) {
+            warn!(error = %err, pgid = self.pgid, "failed to terminate isolated display process group");
+        }
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.wait();
+        }
+        let _ = fs::remove_file(&self.display_file);
+    }
+}
+
+fn terminate_process_group(pgid: i32) -> Result<()> {
+    if !signal_process_group(-pgid, libc::SIGTERM)? {
+        return Ok(());
+    }
+
+    for _ in 0..20 {
+        if !signal_process_group(-pgid, 0)? {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    signal_process_group(-pgid, libc::SIGKILL)?;
+    Ok(())
+}
+
+fn signal_process_group(pgid: i32, signal: i32) -> Result<bool> {
+    let rc = unsafe { libc::kill(pgid, signal) };
+    if rc == 0 {
+        return Ok(true);
+    }
+    let err = io::Error::last_os_error();
+    if err.raw_os_error() == Some(libc::ESRCH) {
+        return Ok(false);
+    }
+    Err(err).with_context(|| format!("failed to send signal {signal} to process group {pgid}"))
+}
+
+fn numeric_arg(args: &[String], flag: &str) -> Option<u32> {
+    let index = args.iter().position(|arg| arg == flag)?;
+    args.get(index + 1)?.parse::<u32>().ok().filter(|value| *value > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{IsolationConfig, IsolationMode};
+
+    #[test]
+    fn display_size_prefers_config_and_falls_back_to_wine_args() {
+        let cfg = IsolationConfig {
+            mode: IsolationMode::GamescopeHeadless,
+            width: Some(1280),
+            height: Some(720),
+            ..IsolationConfig::default()
+        };
+        let args = vec![
+            "-width".to_string(),
+            "2560".to_string(),
+            "-height".to_string(),
+            "1600".to_string(),
+        ];
+
+        let size = resolve_display_size(&cfg, &args);
+
+        assert_eq!(size.width, 1280);
+        assert_eq!(size.height, 720);
+
+        let cfg = IsolationConfig {
+            mode: IsolationMode::GamescopeHeadless,
+            ..IsolationConfig::default()
+        };
+        let args = vec![
+            "-height".to_string(),
+            "1600".to_string(),
+            "-width".to_string(),
+            "2560".to_string(),
+        ];
+        let size = resolve_display_size(&cfg, &args);
+
+        assert_eq!(size.width, 2560);
+        assert_eq!(size.height, 1600);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod app;
 mod cgroup;
 mod cli;
 mod config;
+mod display_isolation;
 mod gnome;
 mod ipc;
 mod logging;


### PR DESCRIPTION
### 目的

解决 `wine-scene` 模式下 Wallpaper Engine 窗口在 Wayland/Niri 中无法隐藏的问题。 例如: #5 

在现有代码实现中，scene 壁纸必须存在一个真实 X11/Wine 窗口，Wallpaper Engine 才会继续渲染；但这个窗口不能最小化、不能 unmap、也不能完全隐藏，否则 XComposite 抓图容易失败。因此，我尝试过 Niri 工作区移动、floating、隐藏脚本等方式，仍然存在主动切换工作区或打开 overview 时看到调试窗口的风险。

本PR 预期让 Wallpaper Engine 窗口继续真实存在并正常渲染，同时彻底从宿主 Wayland compositor 的窗口树中消失，避免用户在 Niri 中看到它。

---

### 解决思路

新增可选的 **Display Isolation（显示隔离）** 机制。

#### 1. 配置示例
引入外部依赖 [gamescope](https://wiki.archlinux.org/title/Gamescope), 通过 Gamescope Headless 模式实现 Wallpaper Engine窗口运行期的 Display 隔离

在配置文件中添加如下可选配置：

```toml
[isolation]
mode = "gamescope_headless" # 可选值: none | gamescope_headless
command = "gamescope"
width = 2560
height = 1600
startup_timeout_secs = 10

```

> **注**：默认配置仍保持 `mode = "none"`

#### 2. 工作原理

当 `isolation.mode = "gamescope_headless"` 时：

1. `we-layerd` 启动一个 headless **gamescope** 实例。
2. **gamescope** 内部创建独立的 XWayland display。
3. Wine / Wallpaper Engine 连接到这个内部 `DISPLAY`。
4. `we-layerd` 同样从这个内部 `DISPLAY` 进行 XComposite 抓图。
5. 宿主 **Niri** 不再管理 Wallpaper Engine 的真实窗口。
6. 原来的宿主 WM 隐藏逻辑会直接跳过（因为窗口已经不在宿主窗口树里）。

通过这种方式，Wallpaper Engine 仍然认为自己拥有一个真实窗口，渲染链路不被破坏；同时，用户在 Niri 中切换工作区、打开 overview、查看窗口列表时，都对该窗口完全不可见。

---

### 代价

* **引入新依赖**：引入了新的可选外部依赖 `gamescope`。
* **内存占用上升**：我基于同一壁纸文件的本地测试，启用前后 PSS 平均值约增加 **70 MiB**（实际运行中可按约 70-80 MiB 的额外内存成本估算）。
* **CPU 影响可忽略**：本地测试中平均 CPU 差异约为 `+0.02%` 单核占用，基本属于测量噪声范围，可忽略不计。
* **环境依赖**：方案依赖系统的 `gamescope` headless 模式可用。

---

### 验证测试

#### 1. 自动化检查与构建

* [x] `cargo fmt --check`
* [x] `cargo test`
* [x] `cargo build --release -p we-layerd`

#### 2. 本地运行验证结果

* [x] 在Niri环境下，Wallpaper Engine scene 正常渲染。
* [x] `we-layerd` 可成功从 gamescope 内部的 XWayland 抓图。
* [x] Niri 窗口列表中不再出现 `WE-DEBUG-WINDOW`。
* [x] 主动切换工作区和打开 overview 时，调试窗口均完全不可见。
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/ab4a735b-0a9c-4aee-a28d-e94962726cc4" />