### PR TITLE
ci: build Fedora RPM packages

### DIFF
--- a/.github/workflows/fedora-rpm.yml
+++ b/.github/workflows/fedora-rpm.yml
@@ -22,9 +22,9 @@ concurrency:
 
 jobs:
   rpm:
-    name: Fedora 43 x86_64 RPM
+    name: Fedora 44 x86_64 RPM
     runs-on: ubuntu-24.04
-    container: fedora:43
+    container: fedora:44
     timeout-minutes: 60
 
     steps:
@@ -72,7 +72,7 @@ jobs:
       - name: Upload packages
         uses: actions/upload-artifact@v4
         with:
-          name: we-layerd-fedora43-x86_64-${{ github.sha }}
+          name: we-layerd-fedora44-x86_64-${{ github.sha }}
           path: |
             package/fedora/out/RPMS/x86_64/*.rpm
             package/fedora/out/SRPMS/*.src.rpm

--- a/.github/workflows/fedora-rpm.yml
+++ b/.github/workflows/fedora-rpm.yml
@@ -10,6 +10,12 @@ on:
 permissions:
   contents: read
 
+env:
+  CARGO_BUILD_JOBS: "2"
+  CARGO_INCREMENTAL: "0"
+  CMAKE_BUILD_PARALLEL_LEVEL: "2"
+  MAKEFLAGS: "-j2"
+
 concurrency:
   group: fedora-rpm-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/fedora-rpm.yml
+++ b/.github/workflows/fedora-rpm.yml
@@ -44,7 +44,7 @@ jobs:
             wayland-devel wayland-protocols-devel xz
 
       - name: Check out source and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -70,7 +70,7 @@ jobs:
           compgen -G 'package/fedora/out/SRPMS/*.src.rpm' >/dev/null
 
       - name: Upload packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: we-layerd-fedora44-x86_64-${{ github.sha }}
           path: |

--- a/.github/workflows/fedora-rpm.yml
+++ b/.github/workflows/fedora-rpm.yml
@@ -1,0 +1,73 @@
+name: Fedora RPM
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fedora-rpm-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rpm:
+    name: Fedora 43 x86_64 RPM
+    runs-on: ubuntu-24.04
+    container: fedora:43
+    timeout-minutes: 60
+
+    steps:
+      - name: Install build dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          dnf install -y \
+            binutils cargo ca-certificates cef-devel cmake coreutils curl \
+            desktop-file-utils findutils fontconfig-devel freetype-devel \
+            gcc-c++ git grep gzip \
+            gstreamer1-devel gstreamer1-plugins-bad-free-devel \
+            gstreamer1-plugins-base-devel gtk3-devel libatomic libdrm-devel \
+            libva-devel libxdo-devel libxkbcommon-devel lz4-devel \
+            mesa-libGL-devel pango-devel patchelf pkgconf-pkg-config \
+            rpm-build rust tar vulkan-headers vulkan-loader-devel \
+            wayland-devel wayland-protocols-devel xz
+
+      - name: Check out source and submodules
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Report build toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustc --version --verbose
+          cargo --version
+          rpmbuild --version
+
+      - name: Build RPM and SRPM
+        shell: bash
+        run: package/fedora/build.sh
+
+      - name: Verify packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          compgen -G 'package/fedora/out/RPMS/x86_64/*.rpm' >/dev/null
+          compgen -G 'package/fedora/out/SRPMS/*.src.rpm' >/dev/null
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: we-layerd-fedora43-x86_64-${{ github.sha }}
+          path: |
+            package/fedora/out/RPMS/x86_64/*.rpm
+            package/fedora/out/SRPMS/*.src.rpm
+          if-no-files-found: error

--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,7 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=.gitmodules");
     println!("cargo:rerun-if-env-changed=CEF_ROOT");
+    println!("cargo:rerun-if-env-changed=CMAKE_BUILD_PARALLEL_LEVEL");
     println!("cargo:rerun-if-env-changed=WE_LAYERD_INSTALL_PREFIX");
     println!("cargo:rerun-if-env-changed=WE_LAYERD_PREBUILT_RENDERER_ROOT");
 
@@ -53,6 +54,7 @@ fn main() {
     ensure_cmake_cache_value(&build_root.join("CMakeCache.txt"), "BUILD_WEWEB:BOOL", "ON")
         .expect("failed to verify BUILD_WEWEB in CMakeCache.txt");
 
+    let parallel_jobs = env::var("CMAKE_BUILD_PARALLEL_LEVEL").unwrap_or_else(|_| "1".into());
     for target in ["wallpaper-engine-renderer", "we-cef-helper"] {
         run(
             Command::new("cmake")
@@ -60,7 +62,8 @@ fn main() {
                 .arg(&build_root)
                 .arg("--target")
                 .arg(target)
-                .arg("--parallel"),
+                .arg("--parallel")
+                .arg(&parallel_jobs),
             &format!("build upstream target {target}"),
         );
     }


### PR DESCRIPTION
## Summary

- add a Fedora 44 container job for pull requests, main pushes, and manual runs
- build the existing RPM and SRPM definitions with the distribution Rust toolchain
- verify and upload both binary and source packages as workflow artifacts

## Safety

- use read-only repository permissions and no secrets
- disable persisted checkout credentials
- avoid restoring executable caches for untrusted pull request code

## Validation

- `actionlint .github/workflows/fedora-rpm.yml`
- `git diff --check`
- verified all listed dependencies are available through Fedora repositories