### PR TITLE
feat: add wallpaper applied command hook

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -21,3 +21,8 @@ options_json = '''
   "example": true
 }
 '''
+
+# Runs asynchronously after the first frame of each successful startup, switch, or reload.
+# [hooks.wallpaper_applied]
+# command = "~/.local/bin/we-theme-sync"
+# args = []

--- a/crates/we-core/src/config.rs
+++ b/crates/we-core/src/config.rs
@@ -19,8 +19,29 @@ pub struct AppConfig {
     pub general: GeneralConfig,
     #[serde(default)]
     pub renderer: RendererConfig,
+    #[serde(default, skip_serializing_if = "HooksConfig::is_empty")]
+    pub hooks: HooksConfig,
     #[serde(default)]
     pub wallpapers: BTreeMap<String, WallpaperSettings>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HooksConfig {
+    #[serde(default)]
+    pub wallpaper_applied: Option<HookCommand>,
+}
+
+impl HooksConfig {
+    pub fn is_empty(&self) -> bool {
+        self.wallpaper_applied.is_none()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HookCommand {
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -103,6 +124,7 @@ pub struct LaunchSettings {
     pub scale_mode: ScaleMode,
     pub force_scene_audio_loop: bool,
     pub options_json: Option<String>,
+    pub hooks: HooksConfig,
     pub wallpapers: BTreeMap<String, WallpaperSettings>,
 }
 
@@ -192,6 +214,7 @@ impl Default for LaunchSettings {
             scale_mode: ScaleMode::Cover,
             force_scene_audio_loop: false,
             options_json: None,
+            hooks: HooksConfig::default(),
             wallpapers: BTreeMap::new(),
         }
     }
@@ -209,6 +232,7 @@ pub fn build_config(settings: &LaunchSettings, project_json: &Path) -> AppConfig
     cfg.renderer.allow_shm_fallback = settings.allow_shm_fallback;
     cfg.renderer.fps = settings.fps_limit.clamp(1, 360);
     cfg.renderer.options_json = settings.options_json.clone();
+    cfg.hooks = settings.hooks.clone();
     cfg.renderer.source = project_json.parent().unwrap_or(project_json).display().to_string();
     cfg.renderer.assets_path =
         Path::new(&settings.assets_path).join("assets").display().to_string();
@@ -280,6 +304,7 @@ pub fn load_launch_settings(path: &Path) -> Result<LaunchSettings> {
         scale_mode: cfg.general.scale_mode,
         force_scene_audio_loop: cfg.general.force_scene_audio_loop,
         options_json: cfg.renderer.options_json,
+        hooks: cfg.hooks,
         wallpapers: cfg.wallpapers,
     })
 }
@@ -390,7 +415,7 @@ mod tests {
 
     use super::{
         build_config, build_config_for_wallpaper, load_launch_settings, merge_scene_source_options,
-        save_force_scene_audio_loop, LaunchSettings, ScaleMode,
+        save_force_scene_audio_loop, HookCommand, HooksConfig, LaunchSettings, ScaleMode,
     };
     use crate::wallpaper::settings::{
         RenderResolution, Rotation, WallpaperFillMode, WallpaperSettings,
@@ -406,12 +431,19 @@ mod tests {
 
     #[test]
     fn build_config_writes_renderer_native_source_and_assets() {
+        let hooks = HooksConfig {
+            wallpaper_applied: Some(HookCommand {
+                command: "theme-sync".to_string(),
+                args: vec!["--force".to_string()],
+            }),
+        };
         let settings = LaunchSettings {
             assets_path: "/steam/steamapps/common/wallpaper_engine".to_string(),
             fps_limit: 144,
             interactive: false,
             scale_mode: ScaleMode::Fit,
             options_json: Some("{\"demo\":true}".to_string()),
+            hooks: hooks.clone(),
             ..LaunchSettings::default()
         };
 
@@ -423,6 +455,7 @@ mod tests {
         assert_eq!(cfg.renderer.options_json.as_deref(), Some("{\"demo\":true}"));
         assert!(!cfg.general.interactive);
         assert_eq!(cfg.general.scale_mode, ScaleMode::Fit);
+        assert_eq!(cfg.hooks, hooks);
     }
 
     #[test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -73,6 +73,29 @@ Current DMA-BUF scope:
 - v4 feedback changes are forwarded while the renderer is running, allowing output rebinding or SHM fallback
 - `prefer_dmabuf` selects policy; `allow_shm_fallback` controls behavior when no compatible pair exists
 
+## Wallpaper applied hook
+
+Use an optional command hook to integrate theme generators such as DMS/Matugen without making
+`we-layerd` depend on a specific desktop shell:
+
+```toml
+[hooks.wallpaper_applied]
+command = "~/.local/bin/we-theme-sync"
+args = []
+```
+
+The command starts asynchronously once the first frame has been submitted for each successful
+startup, wallpaper switch, or reload. Hook startup or exit failures are logged and do not stop the
+wallpaper runtime. `command` is executed directly, not through a shell; put pipelines, redirection,
+or other shell syntax in an executable script instead.
+
+The hook inherits the daemon environment and receives:
+
+- `WE_LAYERD_EVENT=wallpaper_applied`
+- `WE_LAYERD_SOURCE`: the active workshop item directory with `~` expanded
+- `WE_LAYERD_BACKEND`: the active backend name
+- `WE_LAYERD_GENERATION`: the runtime generation number
+
 ## Library search order
 
 If `renderer.library_path` is empty or does not resolve to an existing file, `we-layerd` falls back to these locations:
@@ -88,6 +111,7 @@ If `renderer.library_path` is empty or does not resolve to an existing file, `we
 - it writes `renderer.source` as the selected workshop item directory
 - it derives `renderer.assets_path` from the Wallpaper Engine install path
 - it preserves `renderer.options_json` when re-saving an existing config
+- it preserves `hooks` when generating the selected wallpaper config
 - it merges scene user properties and the optional audio-loop override without discarding other `renderer.options_json` fields
 - it refuses invalid JSON, non-object scene/audio containers, and unsupported options versions instead of overwriting them
 - it no longer generates Wine, Proton, X11 capture, video-native, or `openWallpaper` arguments

--- a/docs/CONFIGURATION.zh-CN.md
+++ b/docs/CONFIGURATION.zh-CN.md
@@ -63,6 +63,28 @@ muted = false
 - v4 feedback 运行中变化时会重新传入 renderer，并重新绑定输出或退回 SHM
 - `prefer_dmabuf` 决定是否优先 DMA-BUF，`allow_shm_fallback` 决定无兼容组合时是否允许退回 SHM
 
+## 壁纸应用 Hook
+
+可以配置一个通用命令 Hook，用于接入 DMS/Matugen 等主题生成器，而不让 `we-layerd`
+直接依赖某个桌面 Shell：
+
+```toml
+[hooks.wallpaper_applied]
+command = "~/.local/bin/we-theme-sync"
+args = []
+```
+
+每次成功启动、切换壁纸或 reload 后，首帧提交成功时会异步启动一次该命令。Hook
+启动失败或退出码非零只会写入日志，不会中止壁纸运行。`command` 会被直接执行，
+不会经过 Shell；管道、重定向等 Shell 语法应写进单独的可执行脚本。
+
+Hook 会继承守护进程环境，并额外收到：
+
+- `WE_LAYERD_EVENT=wallpaper_applied`
+- `WE_LAYERD_SOURCE`：当前 workshop 壁纸目录，已经展开 `~`
+- `WE_LAYERD_BACKEND`：当前后端名称
+- `WE_LAYERD_GENERATION`：当前运行 generation
+
 ## 动态库查找顺序
 
 如果 `renderer.library_path` 为空，或者指向的文件不存在，`we-layerd` 会按以下顺序继续查找：
@@ -78,6 +100,7 @@ muted = false
 - 将 `renderer.source` 写成选中的 workshop 壁纸目录
 - 从 Wallpaper Engine 安装目录推导 `renderer.assets_path`
 - 合并 scene 用户属性和可选的音频循环覆盖，同时保留其它 `renderer.options_json` 字段
+- 生成所选壁纸配置时保留 `hooks` 配置
 - 遇到无效 JSON、非对象的 scene/audio 容器或不支持的 options 版本时会拒绝保存，不会覆盖原配置
 - 不再生成 Wine、Proton、X11 capture、video-native 或 `openWallpaper` 参数
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,6 +21,7 @@ use crate::{
         wayland_common::{connection, registry},
     },
     config::Config,
+    hooks::{self, WallpaperAppliedContext, WallpaperAppliedTrigger},
     ipc::{self, ControlCommand, RuntimeLoopExit},
     runtime::{control::RuntimePhase, status::RuntimeStatusSnapshot},
 };
@@ -300,11 +301,22 @@ fn run_runtime_loop(
     }
 
     let mut backend_impl = backend::create_backend(backend);
+    let mut hook_trigger = WallpaperAppliedTrigger::default();
+    let mut status_sink = |snapshot: RuntimeStatusSnapshot| {
+        let wallpaper_applied = hook_trigger.observe(&snapshot);
+        update_runtime_snapshot(runtime_state, snapshot);
+        if wallpaper_applied {
+            hooks::spawn_wallpaper_applied(
+                cfg.hooks.wallpaper_applied.as_ref(),
+                WallpaperAppliedContext { source: &cfg.renderer.source, backend, generation },
+            );
+        }
+    };
     backend_impl.run(BackendContext {
         cfg: &cfg,
         shutdown_requested,
         control_rx,
-        status_sink: &mut |snapshot| update_runtime_snapshot(runtime_state, snapshot),
+        status_sink: &mut status_sink,
     })
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use std::{fs, path::Path};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use we_core::wallpaper::settings::WallpaperFillMode;
+use we_core::{config::HooksConfig, wallpaper::settings::WallpaperFillMode};
 
 use crate::backend::{gnome::protocol, traits::BackendKind};
 
@@ -14,6 +14,8 @@ pub struct Config {
     pub gnome: GnomeConfig,
     #[serde(default)]
     pub renderer: RendererConfig,
+    #[serde(default, skip_serializing_if = "HooksConfig::is_empty")]
+    pub hooks: HooksConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -257,6 +259,10 @@ mod tests {
             fill_mode = "fit"
             rotation_degrees = 90
 
+            [hooks.wallpaper_applied]
+            command = "theme-sync"
+            args = ["--force"]
+
             [gnome]
             extension_dbus_name = "io.github.weLayerd.Gnome"
         "#;
@@ -274,6 +280,9 @@ mod tests {
         assert_eq!(cfg.renderer.render_height, Some(1080));
         assert_eq!(cfg.renderer.fill_mode, we_core::wallpaper::settings::WallpaperFillMode::Fit);
         assert_eq!(cfg.renderer.rotation_degrees, 90);
+        let hook = cfg.hooks.wallpaper_applied.expect("wallpaper hook");
+        assert_eq!(hook.command, "theme-sync");
+        assert_eq!(hook.args, ["--force"]);
     }
 
     #[test]

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,0 +1,112 @@
+use std::{
+    process::{Command, Stdio},
+    thread,
+};
+
+use tracing::{info, warn};
+use we_core::{config::HookCommand, install_layout::expand_tilde};
+
+use crate::{backend::traits::BackendKind, runtime::status::RuntimeStatusSnapshot};
+
+#[derive(Debug, Default)]
+pub(crate) struct WallpaperAppliedTrigger {
+    fired: bool,
+}
+
+impl WallpaperAppliedTrigger {
+    pub(crate) fn observe(&mut self, snapshot: &RuntimeStatusSnapshot) -> bool {
+        if self.fired || snapshot.frame_stats.presented == 0 {
+            return false;
+        }
+
+        self.fired = true;
+        true
+    }
+}
+
+pub(crate) struct WallpaperAppliedContext<'a> {
+    pub(crate) source: &'a str,
+    pub(crate) backend: BackendKind,
+    pub(crate) generation: u64,
+}
+
+pub(crate) fn spawn_wallpaper_applied(
+    hook: Option<&HookCommand>,
+    context: WallpaperAppliedContext<'_>,
+) {
+    let Some(hook) = hook else {
+        return;
+    };
+    if hook.command.trim().is_empty() {
+        warn!("wallpaper_applied hook command is empty; skipping");
+        return;
+    }
+
+    let program = expand_tilde(hook.command.trim());
+    let source = expand_tilde(context.source).display().to_string();
+    let mut command = Command::new(&program);
+    command
+        .args(&hook.args)
+        .stdin(Stdio::null())
+        .env("WE_LAYERD_EVENT", "wallpaper_applied")
+        .env("WE_LAYERD_SOURCE", &source)
+        .env("WE_LAYERD_BACKEND", context.backend.as_config_str())
+        .env("WE_LAYERD_GENERATION", context.generation.to_string());
+
+    let child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            warn!(
+                command = %hook.command,
+                %error,
+                "failed to start wallpaper_applied hook"
+            );
+            return;
+        }
+    };
+
+    let command_name = hook.command.clone();
+    let _waiter = thread::spawn(move || {
+        let mut child = child;
+        match child.wait() {
+            Ok(status) if status.success() => {
+                info!(command = %command_name, "wallpaper_applied hook completed");
+            }
+            Ok(status) => {
+                warn!(
+                    command = %command_name,
+                    exit_status = %status,
+                    "wallpaper_applied hook failed"
+                );
+            }
+            Err(error) => {
+                warn!(
+                    command = %command_name,
+                    %error,
+                    "failed to wait for wallpaper_applied hook"
+                );
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::runtime::status::RuntimeStatusSnapshot;
+
+    use super::WallpaperAppliedTrigger;
+
+    #[test]
+    fn wallpaper_applied_fires_once_after_the_first_presented_frame() {
+        let mut trigger = WallpaperAppliedTrigger::default();
+        let mut snapshot = RuntimeStatusSnapshot::default();
+
+        assert!(!trigger.observe(&snapshot));
+
+        snapshot.frame_stats.presented = 1;
+        assert!(trigger.observe(&snapshot));
+
+        snapshot.frame_stats.presented = 2;
+        assert!(!trigger.observe(&snapshot));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod app;
 mod backend;
 mod cli;
 mod config;
+mod hooks;
 mod ipc;
 mod logging;
 mod runtime;


### PR DESCRIPTION
## Summary

- add an optional `hooks.wallpaper_applied` command hook
- trigger it asynchronously after the first submitted frame of each startup, reload, or wallpaper switch
- pass the active source, backend, event name, and generation through environment variables
- preserve hook configuration when `we-gui` regenerates the selected wallpaper config
- document DMS/Matugen integration without adding a hard dependency

## Validation

- `cargo test --workspace`
- `cargo clippy -p we-layerd -p we-core --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

Closes #18