### PR TITLE
feat: add daemon-managed playlist runtime

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -26,3 +26,15 @@ options_json = '''
 # [hooks.wallpaper_applied]
 # command = "~/.local/bin/we-theme-sync"
 # args = []
+
+# Optional daemon-managed playlist. The GUI will manage these entries in a later phase.
+# [playlists]
+# active = "Daily"
+#
+# [playlists.definitions.Daily]
+# mode = "repeat"
+# default_duration_ms = 1800000
+#
+# [[playlists.definitions.Daily.items]]
+# wallpaper_id = "1234567890"
+# source = "/path/to/Steam/steamapps/workshop/content/431960/1234567890"

--- a/crates/we-core/src/config.rs
+++ b/crates/we-core/src/config.rs
@@ -9,7 +9,10 @@ use std::{
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::wallpaper::settings::{RenderResolution, WallpaperFillMode, WallpaperSettings};
+use crate::{
+    playlist::PlaylistConfig,
+    wallpaper::settings::{RenderResolution, WallpaperFillMode, WallpaperSettings},
+};
 
 static CONFIG_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -23,6 +26,8 @@ pub struct AppConfig {
     pub hooks: HooksConfig,
     #[serde(default)]
     pub wallpapers: BTreeMap<String, WallpaperSettings>,
+    #[serde(default)]
+    pub playlists: PlaylistConfig,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -126,6 +131,7 @@ pub struct LaunchSettings {
     pub options_json: Option<String>,
     pub hooks: HooksConfig,
     pub wallpapers: BTreeMap<String, WallpaperSettings>,
+    pub playlists: PlaylistConfig,
 }
 
 fn default_interactive() -> bool {
@@ -216,6 +222,7 @@ impl Default for LaunchSettings {
             options_json: None,
             hooks: HooksConfig::default(),
             wallpapers: BTreeMap::new(),
+            playlists: PlaylistConfig::default(),
         }
     }
 }
@@ -233,6 +240,7 @@ pub fn build_config(settings: &LaunchSettings, project_json: &Path) -> AppConfig
     cfg.renderer.fps = settings.fps_limit.clamp(1, 360);
     cfg.renderer.options_json = settings.options_json.clone();
     cfg.hooks = settings.hooks.clone();
+    cfg.playlists = settings.playlists.clone();
     cfg.renderer.source = project_json.parent().unwrap_or(project_json).display().to_string();
     cfg.renderer.assets_path =
         Path::new(&settings.assets_path).join("assets").display().to_string();
@@ -268,6 +276,7 @@ pub fn build_config_for_wallpaper(
         settings.force_scene_audio_loop,
     )?);
     config.wallpapers = settings.wallpapers.clone();
+    config.playlists = settings.playlists.clone();
     Ok(config)
 }
 
@@ -306,6 +315,7 @@ pub fn load_launch_settings(path: &Path) -> Result<LaunchSettings> {
         options_json: cfg.renderer.options_json,
         hooks: cfg.hooks,
         wallpapers: cfg.wallpapers,
+        playlists: cfg.playlists,
     })
 }
 

--- a/crates/we-core/src/lib.rs
+++ b/crates/we-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
 pub mod install_layout;
+pub mod playlist;
 pub mod steam;
 pub mod wallpaper;

--- a/crates/we-core/src/playlist.rs
+++ b/crates/we-core/src/playlist.rs
@@ -148,7 +148,7 @@ impl PlaylistCursor {
         }
 
         let index = if playlist.mode == PlaylistMode::Shuffle {
-            self.refill_shuffle_bag(None);
+            self.refill_shuffle_bag();
             self.take_random_from_bag()?
         } else {
             0
@@ -180,9 +180,9 @@ impl PlaylistCursor {
                     Some(forward)
                 } else {
                     if self.shuffle_remaining.is_empty() {
-                        self.refill_shuffle_bag(Some(current));
+                        self.refill_shuffle_bag();
                     }
-                    self.take_random_from_bag()
+                    self.take_random_from_bag_avoiding(Some(current))
                 }
             }
         }?;
@@ -226,17 +226,30 @@ impl PlaylistCursor {
         self.forward_history.retain(|index| *index < item_count);
     }
 
-    fn refill_shuffle_bag(&mut self, exclude: Option<usize>) {
-        self.shuffle_remaining =
-            (0..self.item_count).filter(|index| Some(*index) != exclude).collect();
+    fn refill_shuffle_bag(&mut self) {
+        self.shuffle_remaining = (0..self.item_count).collect();
     }
 
     fn take_random_from_bag(&mut self) -> Option<usize> {
+        self.take_random_from_bag_avoiding(None)
+    }
+
+    fn take_random_from_bag_avoiding(&mut self, avoid: Option<usize>) -> Option<usize> {
         if self.shuffle_remaining.is_empty() {
             return None;
         }
-        let index = self.next_random_index(self.shuffle_remaining.len());
-        Some(self.shuffle_remaining.swap_remove(index))
+        let candidates = self
+            .shuffle_remaining
+            .iter()
+            .enumerate()
+            .filter_map(|(position, item)| (Some(*item) != avoid).then_some(position))
+            .collect::<Vec<_>>();
+        let position = if candidates.is_empty() {
+            self.next_random_index(self.shuffle_remaining.len())
+        } else {
+            candidates[self.next_random_index(candidates.len())]
+        };
+        Some(self.shuffle_remaining.swap_remove(position))
     }
 
     fn next_random_index(&mut self, upper_bound: usize) -> usize {
@@ -333,8 +346,14 @@ mod tests {
         cycle.sort_unstable();
         assert_eq!(cycle, vec![0, 1, 2, 3]);
 
-        let next_cycle = cursor.next(&playlist).expect("next cycle starts");
-        assert_ne!(next_cycle, fourth);
+        let fifth = cursor.next(&playlist).expect("next cycle starts");
+        let sixth = cursor.next(&playlist).expect("next cycle continues");
+        let seventh = cursor.next(&playlist).expect("next cycle continues");
+        let eighth = cursor.next(&playlist).expect("next cycle completes");
+        assert_ne!(fifth, fourth);
+        let mut second_cycle = vec![fifth, sixth, seventh, eighth];
+        second_cycle.sort_unstable();
+        assert_eq!(second_cycle, vec![0, 1, 2, 3]);
     }
 
     #[test]

--- a/crates/we-core/src/playlist.rs
+++ b/crates/we-core/src/playlist.rs
@@ -1,0 +1,358 @@
+use std::{collections::BTreeMap, time::Duration};
+
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_PLAYLIST_DURATION_MS: u64 = 1_800_000;
+pub const MIN_PLAYLIST_DURATION_MS: u64 = 100;
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PlaylistMode {
+    #[default]
+    Sequential,
+    Repeat,
+    Shuffle,
+    Manual,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlaylistItem {
+    pub wallpaper_id: String,
+    pub source: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Playlist {
+    #[serde(default)]
+    pub mode: PlaylistMode,
+    #[serde(default = "default_playlist_duration_ms")]
+    pub default_duration_ms: u64,
+    #[serde(default)]
+    pub items: Vec<PlaylistItem>,
+}
+
+impl Default for Playlist {
+    fn default() -> Self {
+        Self {
+            mode: PlaylistMode::Sequential,
+            default_duration_ms: default_playlist_duration_ms(),
+            items: Vec::new(),
+        }
+    }
+}
+
+impl Playlist {
+    pub fn duration_ms_for(&self, index: usize) -> Option<u64> {
+        self.items.get(index).map(|item| {
+            item.duration_ms.unwrap_or(self.default_duration_ms).max(MIN_PLAYLIST_DURATION_MS)
+        })
+    }
+
+    pub fn timed_duration_for(&self, index: usize) -> Option<Duration> {
+        if self.mode == PlaylistMode::Manual {
+            return None;
+        }
+        self.duration_ms_for(index).map(Duration::from_millis)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlaylistConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active: Option<String>,
+    #[serde(default)]
+    pub definitions: BTreeMap<String, Playlist>,
+}
+
+impl PlaylistConfig {
+    pub fn active_playlist(&self) -> Option<(&str, &Playlist)> {
+        let name = self.active.as_deref()?;
+        self.definitions.get(name).map(|playlist| (name, playlist))
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlaylistCursorSnapshot {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current: Option<usize>,
+    #[serde(default)]
+    pub shuffle_remaining: Vec<usize>,
+    #[serde(default)]
+    pub history: Vec<usize>,
+    #[serde(default)]
+    pub forward_history: Vec<usize>,
+    #[serde(default)]
+    pub random_state: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlaylistCursor {
+    item_count: usize,
+    current: Option<usize>,
+    shuffle_remaining: Vec<usize>,
+    history: Vec<usize>,
+    forward_history: Vec<usize>,
+    random_state: u64,
+}
+
+impl PlaylistCursor {
+    pub fn new(item_count: usize, random_seed: u64) -> Self {
+        Self {
+            item_count,
+            current: None,
+            shuffle_remaining: Vec::new(),
+            history: Vec::new(),
+            forward_history: Vec::new(),
+            random_state: normalize_random_state(random_seed),
+        }
+    }
+
+    pub fn restore(item_count: usize, snapshot: PlaylistCursorSnapshot) -> Self {
+        let valid = |index: &usize| *index < item_count;
+        Self {
+            item_count,
+            current: snapshot.current.filter(|index| *index < item_count),
+            shuffle_remaining: deduplicate_indices(
+                snapshot.shuffle_remaining.into_iter().filter(valid),
+            ),
+            history: snapshot.history.into_iter().filter(valid).collect(),
+            forward_history: snapshot.forward_history.into_iter().filter(valid).collect(),
+            random_state: normalize_random_state(snapshot.random_state),
+        }
+    }
+
+    pub fn snapshot(&self) -> PlaylistCursorSnapshot {
+        PlaylistCursorSnapshot {
+            current: self.current,
+            shuffle_remaining: self.shuffle_remaining.clone(),
+            history: self.history.clone(),
+            forward_history: self.forward_history.clone(),
+            random_state: self.random_state,
+        }
+    }
+
+    pub fn current_index(&self) -> Option<usize> {
+        self.current.filter(|index| *index < self.item_count)
+    }
+
+    pub fn start(&mut self, playlist: &Playlist) -> Option<usize> {
+        self.sync_item_count(playlist.items.len());
+        if self.item_count == 0 {
+            self.current = None;
+            return None;
+        }
+        if let Some(current) = self.current_index() {
+            return Some(current);
+        }
+
+        let index = if playlist.mode == PlaylistMode::Shuffle {
+            self.refill_shuffle_bag(None);
+            self.take_random_from_bag()?
+        } else {
+            0
+        };
+        self.current = Some(index);
+        Some(index)
+    }
+
+    pub fn next(&mut self, playlist: &Playlist) -> Option<usize> {
+        self.sync_item_count(playlist.items.len());
+        if self.item_count == 0 {
+            self.current = None;
+            return None;
+        }
+        if self.current.is_none() {
+            return self.start(playlist);
+        }
+
+        let current = self.current?;
+        let replaying_forward =
+            playlist.mode == PlaylistMode::Shuffle && !self.forward_history.is_empty();
+        let next = match playlist.mode {
+            PlaylistMode::Sequential => {
+                current.checked_add(1).filter(|next| *next < self.item_count)
+            }
+            PlaylistMode::Repeat | PlaylistMode::Manual => Some((current + 1) % self.item_count),
+            PlaylistMode::Shuffle => {
+                if let Some(forward) = self.forward_history.pop() {
+                    Some(forward)
+                } else {
+                    if self.shuffle_remaining.is_empty() {
+                        self.refill_shuffle_bag(Some(current));
+                    }
+                    self.take_random_from_bag()
+                }
+            }
+        }?;
+
+        self.history.push(current);
+        if !replaying_forward {
+            self.forward_history.clear();
+        }
+        self.current = Some(next);
+        Some(next)
+    }
+
+    pub fn previous(&mut self, playlist: &Playlist) -> Option<usize> {
+        self.sync_item_count(playlist.items.len());
+        let current = self.current?;
+        let previous = match playlist.mode {
+            PlaylistMode::Sequential => current.checked_sub(1),
+            PlaylistMode::Repeat | PlaylistMode::Manual => {
+                Some(if current == 0 { self.item_count.checked_sub(1)? } else { current - 1 })
+            }
+            PlaylistMode::Shuffle => self.history.pop(),
+        }?;
+
+        if playlist.mode == PlaylistMode::Shuffle {
+            self.forward_history.push(current);
+        }
+        self.current = Some(previous);
+        Some(previous)
+    }
+
+    fn sync_item_count(&mut self, item_count: usize) {
+        if self.item_count == item_count {
+            return;
+        }
+        self.item_count = item_count;
+        if self.current.is_some_and(|index| index >= item_count) {
+            self.current = None;
+        }
+        self.shuffle_remaining.retain(|index| *index < item_count);
+        self.history.retain(|index| *index < item_count);
+        self.forward_history.retain(|index| *index < item_count);
+    }
+
+    fn refill_shuffle_bag(&mut self, exclude: Option<usize>) {
+        self.shuffle_remaining =
+            (0..self.item_count).filter(|index| Some(*index) != exclude).collect();
+    }
+
+    fn take_random_from_bag(&mut self) -> Option<usize> {
+        if self.shuffle_remaining.is_empty() {
+            return None;
+        }
+        let index = self.next_random_index(self.shuffle_remaining.len());
+        Some(self.shuffle_remaining.swap_remove(index))
+    }
+
+    fn next_random_index(&mut self, upper_bound: usize) -> usize {
+        debug_assert!(upper_bound > 0);
+        let mut state = self.random_state;
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        self.random_state = normalize_random_state(state);
+        (self.random_state as usize) % upper_bound
+    }
+}
+
+fn default_playlist_duration_ms() -> u64 {
+    DEFAULT_PLAYLIST_DURATION_MS
+}
+
+fn normalize_random_state(state: u64) -> u64 {
+    if state == 0 {
+        0x9e37_79b9_7f4a_7c15
+    } else {
+        state
+    }
+}
+
+fn deduplicate_indices(indices: impl IntoIterator<Item = usize>) -> Vec<usize> {
+    let mut unique = Vec::new();
+    for index in indices {
+        if !unique.contains(&index) {
+            unique.push(index);
+        }
+    }
+    unique
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Playlist, PlaylistCursor, PlaylistItem, PlaylistMode};
+
+    fn item(id: &str) -> PlaylistItem {
+        PlaylistItem {
+            wallpaper_id: id.to_string(),
+            source: format!("/workshop/{id}"),
+            duration_ms: None,
+        }
+    }
+
+    #[test]
+    fn sequential_playback_preserves_duplicate_entries_and_stops_at_the_end() {
+        let playlist = Playlist {
+            mode: PlaylistMode::Sequential,
+            default_duration_ms: 30_000,
+            items: vec![item("alpha"), item("alpha"), item("beta")],
+        };
+        let mut cursor = PlaylistCursor::new(playlist.items.len(), 7);
+
+        assert_eq!(cursor.start(&playlist), Some(0));
+        assert_eq!(cursor.next(&playlist), Some(1));
+        assert_eq!(cursor.next(&playlist), Some(2));
+        assert_eq!(cursor.next(&playlist), None);
+    }
+
+    #[test]
+    fn repeat_wraps_while_manual_mode_never_requests_timed_progression() {
+        let repeat = Playlist {
+            mode: PlaylistMode::Repeat,
+            default_duration_ms: 1_000,
+            items: vec![item("alpha"), item("beta")],
+        };
+        let mut cursor = PlaylistCursor::new(repeat.items.len(), 11);
+        assert_eq!(cursor.start(&repeat), Some(0));
+        assert_eq!(cursor.next(&repeat), Some(1));
+        assert_eq!(cursor.next(&repeat), Some(0));
+
+        let manual = Playlist { mode: PlaylistMode::Manual, ..repeat };
+        assert_eq!(manual.timed_duration_for(0), None);
+        assert_eq!(manual.timed_duration_for(1), None);
+    }
+
+    #[test]
+    fn shuffle_bag_visits_every_entry_before_reusing_one() {
+        let playlist = Playlist {
+            mode: PlaylistMode::Shuffle,
+            default_duration_ms: 1_000,
+            items: vec![item("a"), item("b"), item("c"), item("d")],
+        };
+        let mut cursor = PlaylistCursor::new(playlist.items.len(), 0x1234_5678);
+        let first = cursor.start(&playlist).expect("first item");
+        let second = cursor.next(&playlist).expect("second item");
+        let third = cursor.next(&playlist).expect("third item");
+        let fourth = cursor.next(&playlist).expect("fourth item");
+
+        let mut cycle = vec![first, second, third, fourth];
+        cycle.sort_unstable();
+        assert_eq!(cycle, vec![0, 1, 2, 3]);
+
+        let next_cycle = cursor.next(&playlist).expect("next cycle starts");
+        assert_ne!(next_cycle, fourth);
+    }
+
+    #[test]
+    fn snapshot_restores_current_position_and_shuffle_history() {
+        let playlist = Playlist {
+            mode: PlaylistMode::Shuffle,
+            default_duration_ms: 1_000,
+            items: vec![item("a"), item("b"), item("c")],
+        };
+        let mut cursor = PlaylistCursor::new(playlist.items.len(), 99);
+        cursor.start(&playlist);
+        cursor.next(&playlist);
+        let expected_current = cursor.current_index();
+        let expected_previous = cursor.previous(&playlist);
+
+        let snapshot = cursor.snapshot();
+        let mut restored = PlaylistCursor::restore(playlist.items.len(), snapshot);
+        assert_eq!(restored.current_index(), expected_previous);
+        assert_eq!(restored.next(&playlist), expected_current);
+    }
+}

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -17,6 +17,18 @@ we-layerd ctl reload
 we-layerd ctl status
 ```
 
+Daemon-managed playlists keep progressing when `we-gui` is closed:
+
+```bash
+we-layerd playlist play "Daily"
+we-layerd playlist next
+we-layerd playlist previous
+we-layerd playlist stop
+```
+
+`playlist stop` stops playlist progression and leaves the currently rendered wallpaper running.
+Playlist position is restored after daemon restart; the restored entry starts with a fresh timer.
+
 Other commands:
 ```bash
 we-layerd doctor

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -73,6 +73,38 @@ Current DMA-BUF scope:
 - v4 feedback changes are forwarded while the renderer is running, allowing output rebinding or SHM fallback
 - `prefer_dmabuf` selects policy; `allow_shm_fallback` controls behavior when no compatible pair exists
 
+## Playlists
+
+Named playlists are part of the daemon configuration, so timing and progression do not depend on
+the GUI process. Entries are ordered references to Workshop item directories and may repeat the
+same wallpaper more than once.
+
+```toml
+[playlists]
+active = "Daily"
+
+[playlists.definitions.Daily]
+mode = "repeat"
+default_duration_ms = 1800000
+
+[[playlists.definitions.Daily.items]]
+wallpaper_id = "1234567890"
+source = "/path/to/Steam/steamapps/workshop/content/431960/1234567890"
+
+[[playlists.definitions.Daily.items]]
+wallpaper_id = "9876543210"
+source = "/path/to/Steam/steamapps/workshop/content/431960/9876543210"
+duration_ms = 300000
+```
+
+Modes are `sequential`, `repeat`, `shuffle`, and `manual`. Sequential playback stops progressing
+after the final entry, repeat wraps in order, shuffle uses a bag so an entry is not reused until the
+current bag is exhausted, and manual only changes through explicit next/previous control. Missing
+Workshop items are skipped rather than terminating a repeat/shuffle playlist.
+
+Playlist runtime state is stored separately from the renderer configuration. On daemon restart the
+current playlist entry and shuffle history are restored, while that entry's timer restarts from zero.
+
 ## Wallpaper applied hook
 
 Use an optional command hook to integrate theme generators such as DMS/Matugen without making

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,8 @@ use std::{
         atomic::{AtomicBool, Ordering},
         mpsc, Arc, Mutex,
     },
+    thread,
+    time::{Duration, Instant},
 };
 
 use anyhow::{anyhow, Context, Result};
@@ -22,23 +24,49 @@ use crate::{
     },
     config::Config,
     hooks::{self, WallpaperAppliedContext, WallpaperAppliedTrigger},
-    ipc::{self, ControlCommand, RuntimeLoopExit},
-    runtime::{control::RuntimePhase, status::RuntimeStatusSnapshot},
+    ipc::{self, ControlCommand, PlaylistCommand, RuntimeLoopExit},
+    runtime::{
+        control::RuntimePhase,
+        playlist::{self, AdvanceDirection, PlaylistRuntime, PlaylistSelection},
+        status::RuntimeStatusSnapshot,
+    },
 };
 
 pub fn run(config_path: Option<&Path>) -> Result<()> {
-    let cfg = Config::load(config_path)?;
+    let mut cfg = Config::load(config_path)?;
+    let playlist_state_path = playlist::state_path_for_config(config_path);
+    let now = Instant::now();
+    let mut playlist_runtime =
+        match playlist_state_path.as_deref().map(playlist::load_snapshot).transpose() {
+            Ok(Some(Some(snapshot))) => {
+                PlaylistRuntime::restore(cfg.playlists.clone(), snapshot, now)
+            }
+            Ok(_) => PlaylistRuntime::new(cfg.playlists.clone(), playlist::random_seed()),
+            Err(error) => {
+                warn!(error = %error, "ignoring invalid playlist runtime state");
+                PlaylistRuntime::new(cfg.playlists.clone(), playlist::random_seed())
+            }
+        };
+    if let Some(selection) = select_initial_playlist_item(&mut playlist_runtime, now) {
+        playlist::apply_selection_to_config(&mut cfg, &selection)?;
+    }
+    persist_playlist_runtime(playlist_state_path.as_deref(), &playlist_runtime);
+    let playlist_runtime = Arc::new(Mutex::new(playlist_runtime));
+
     let (control_tx, control_rx) = mpsc::channel::<ControlCommand>();
     let desired_cfg = Arc::new(Mutex::new(cfg.clone()));
     let current_cfg = Arc::new(Mutex::new(cfg.clone()));
     let runtime_cfg_toml = Arc::new(Mutex::new(cfg.to_toml_pretty()?));
     let runtime_state = Arc::new(Mutex::new(RuntimeState::new(&cfg)));
     let shutdown_requested = Arc::new(AtomicBool::new(false));
+    let scheduler_stop = Arc::new(AtomicBool::new(false));
     install_runtime_ctrlc_handler(control_tx.clone(), shutdown_requested.clone())?;
 
     let status_state = runtime_state.clone();
+    let status_playlist = playlist_runtime.clone();
     let command_tx = control_tx.clone();
     let switch_tx = control_tx.clone();
+    let playlist_tx = control_tx.clone();
 
     let _control_server = ipc::ControlServer::start(
         control_tx,
@@ -53,35 +81,161 @@ pub fn run(config_path: Option<&Path>) -> Result<()> {
                     status.push_str("\n\n");
                     status.push_str(&guard.render_status_toml());
                 }
+                if let Ok(guard) = status_playlist.lock() {
+                    status.push_str("\n\n");
+                    status.push_str(&guard.render_status_toml());
+                }
                 status
             }
         },
         {
             let runtime_state = runtime_state.clone();
-            move |cmd| handle_runtime_control_command(cmd, &command_tx, &runtime_state)
+            let playlist_runtime = playlist_runtime.clone();
+            let scheduler_stop = scheduler_stop.clone();
+            let playlist_state_path = playlist_state_path.clone();
+            move |cmd| {
+                let handled = handle_runtime_control_command(cmd, &command_tx, &runtime_state)?;
+                let now = Instant::now();
+                if let Ok(mut runtime) = playlist_runtime.lock() {
+                    match cmd {
+                        ControlCommand::Pause => runtime.pause(now),
+                        ControlCommand::Resume => runtime.resume(now),
+                        ControlCommand::Stop => scheduler_stop.store(true, Ordering::Relaxed),
+                        _ => {}
+                    }
+                    persist_playlist_runtime(playlist_state_path.as_deref(), &runtime);
+                }
+                Ok(handled)
+            }
         },
         {
             let desired_cfg = desired_cfg.clone();
             let runtime_cfg_toml = runtime_cfg_toml.clone();
             let runtime_state = runtime_state.clone();
+            let playlist_runtime = playlist_runtime.clone();
+            let playlist_state_path = playlist_state_path.clone();
+            let switch_tx = switch_tx.clone();
             move |config_path| {
-                let next_cfg = Config::load(Some(config_path))?;
-                if let Ok(mut guard) = desired_cfg.lock() {
-                    *guard = next_cfg.clone();
+                let mut next_cfg = Config::load(Some(config_path))?;
+                let now = Instant::now();
+                if let Ok(mut runtime) = playlist_runtime.lock() {
+                    runtime.configure(next_cfg.playlists.clone(), now);
+                    if let Some(selection) = select_initial_playlist_item(&mut runtime, now) {
+                        playlist::apply_selection_to_config(&mut next_cfg, &selection)?;
+                    }
+                    persist_playlist_runtime(playlist_state_path.as_deref(), &runtime);
                 }
-                if let Ok(mut guard) = runtime_cfg_toml.lock() {
-                    *guard = next_cfg.to_toml_pretty()?;
+                schedule_config_reconfigure(
+                    next_cfg,
+                    &desired_cfg,
+                    &runtime_cfg_toml,
+                    &runtime_state,
+                    &switch_tx,
+                )
+            }
+        },
+        {
+            let desired_cfg = desired_cfg.clone();
+            let runtime_cfg_toml = runtime_cfg_toml.clone();
+            let runtime_state = runtime_state.clone();
+            let playlist_runtime = playlist_runtime.clone();
+            let playlist_state_path = playlist_state_path.clone();
+            move |command| {
+                let now = Instant::now();
+                let (selection, active_name) = {
+                    let mut runtime = playlist_runtime
+                        .lock()
+                        .map_err(|_| anyhow!("playlist runtime lock poisoned"))?;
+                    let selection = match &command {
+                        PlaylistCommand::Play(name) => {
+                            let first = runtime.play(name, now).map_err(anyhow::Error::msg)?;
+                            if playlist_selection_is_available(&first) {
+                                Some(first)
+                            } else {
+                                runtime.advance(
+                                    AdvanceDirection::Next,
+                                    now,
+                                    playlist_item_is_available,
+                                )
+                            }
+                        }
+                        PlaylistCommand::Next => {
+                            runtime.advance(AdvanceDirection::Next, now, playlist_item_is_available)
+                        }
+                        PlaylistCommand::Previous => runtime.advance(
+                            AdvanceDirection::Previous,
+                            now,
+                            playlist_item_is_available,
+                        ),
+                        PlaylistCommand::Stop => {
+                            runtime.stop();
+                            None
+                        }
+                    };
+                    persist_playlist_runtime(playlist_state_path.as_deref(), &runtime);
+                    (selection, runtime.active_name().map(str::to_string))
+                };
+
+                if matches!(command, PlaylistCommand::Stop) {
+                    update_playlist_active_config(None, &desired_cfg, &runtime_cfg_toml)?;
+                    return Ok(());
                 }
-                if let Ok(mut state) = runtime_state.lock() {
-                    state.begin_switch(&next_cfg);
-                }
-                switch_tx
-                    .send(ControlCommand::Reconfigure)
-                    .context("failed to schedule runtime reconfiguration")?;
-                Ok(())
+
+                let selection =
+                    selection.ok_or_else(|| anyhow!("playlist has no playable item"))?;
+                schedule_playlist_selection(
+                    selection,
+                    active_name,
+                    &desired_cfg,
+                    &runtime_cfg_toml,
+                    &runtime_state,
+                    &playlist_tx,
+                )
             }
         },
     )?;
+
+    {
+        let desired_cfg = desired_cfg.clone();
+        let runtime_cfg_toml = runtime_cfg_toml.clone();
+        let runtime_state = runtime_state.clone();
+        let playlist_runtime = playlist_runtime.clone();
+        let playlist_state_path = playlist_state_path.clone();
+        let shutdown_requested = shutdown_requested.clone();
+        let scheduler_stop = scheduler_stop.clone();
+        let scheduler_tx = switch_tx.clone();
+        thread::spawn(move || {
+            while !shutdown_requested.load(Ordering::Relaxed)
+                && !scheduler_stop.load(Ordering::Relaxed)
+            {
+                thread::sleep(Duration::from_millis(50));
+                let now = Instant::now();
+                let (selection, active_name) = {
+                    let Ok(mut runtime) = playlist_runtime.lock() else {
+                        break;
+                    };
+                    let selection = runtime.due_selection(now, playlist_item_is_available);
+                    if selection.is_some() {
+                        persist_playlist_runtime(playlist_state_path.as_deref(), &runtime);
+                    }
+                    (selection, runtime.active_name().map(str::to_string))
+                };
+                let Some(selection) = selection else {
+                    continue;
+                };
+                if let Err(error) = schedule_playlist_selection(
+                    selection,
+                    active_name,
+                    &desired_cfg,
+                    &runtime_cfg_toml,
+                    &runtime_state,
+                    &scheduler_tx,
+                ) {
+                    warn!(error = %error, "failed to advance playlist");
+                }
+            }
+        });
+    }
 
     loop {
         let next_cfg = desired_cfg
@@ -124,12 +278,98 @@ pub fn run(config_path: Option<&Path>) -> Result<()> {
         }
 
         match exit {
-            RuntimeLoopExit::Stop => break,
+            RuntimeLoopExit::Stop => {
+                scheduler_stop.store(true, Ordering::Relaxed);
+                break;
+            }
             RuntimeLoopExit::RestartCurrent | RuntimeLoopExit::Reconfigure => continue,
         }
     }
 
     Ok(())
+}
+
+fn select_initial_playlist_item(
+    runtime: &mut PlaylistRuntime,
+    now: Instant,
+) -> Option<PlaylistSelection> {
+    let selection = runtime.ensure_started(now)?;
+    if playlist_selection_is_available(&selection) {
+        return Some(selection);
+    }
+    runtime.advance(AdvanceDirection::Next, now, playlist_item_is_available)
+}
+
+fn playlist_selection_is_available(selection: &PlaylistSelection) -> bool {
+    Path::new(&selection.source).join("project.json").is_file()
+}
+
+fn playlist_item_is_available(item: &we_core::playlist::PlaylistItem) -> bool {
+    Path::new(&item.source).join("project.json").is_file()
+}
+
+fn persist_playlist_runtime(path: Option<&Path>, runtime: &PlaylistRuntime) {
+    let (Some(path), Some(snapshot)) = (path, runtime.snapshot()) else {
+        return;
+    };
+    if let Err(error) = playlist::save_snapshot(path, &snapshot) {
+        warn!(error = %error, "failed to persist playlist runtime state");
+    }
+}
+
+fn update_playlist_active_config(
+    active_name: Option<String>,
+    desired_cfg: &Arc<Mutex<Config>>,
+    runtime_cfg_toml: &Arc<Mutex<String>>,
+) -> Result<()> {
+    let mut next_cfg = desired_cfg
+        .lock()
+        .map_err(|_| anyhow!("failed to update desired playlist config"))?
+        .clone();
+    next_cfg.playlists.active = active_name;
+    if let Ok(mut guard) = desired_cfg.lock() {
+        *guard = next_cfg.clone();
+    }
+    if let Ok(mut guard) = runtime_cfg_toml.lock() {
+        *guard = next_cfg.to_toml_pretty()?;
+    }
+    Ok(())
+}
+
+fn schedule_playlist_selection(
+    selection: PlaylistSelection,
+    active_name: Option<String>,
+    desired_cfg: &Arc<Mutex<Config>>,
+    runtime_cfg_toml: &Arc<Mutex<String>>,
+    runtime_state: &Arc<Mutex<RuntimeState>>,
+    control_tx: &mpsc::Sender<ControlCommand>,
+) -> Result<()> {
+    let mut next_cfg =
+        desired_cfg.lock().map_err(|_| anyhow!("failed to read desired playlist config"))?.clone();
+    next_cfg.playlists.active = active_name;
+    playlist::apply_selection_to_config(&mut next_cfg, &selection)?;
+    schedule_config_reconfigure(next_cfg, desired_cfg, runtime_cfg_toml, runtime_state, control_tx)
+}
+
+fn schedule_config_reconfigure(
+    next_cfg: Config,
+    desired_cfg: &Arc<Mutex<Config>>,
+    runtime_cfg_toml: &Arc<Mutex<String>>,
+    runtime_state: &Arc<Mutex<RuntimeState>>,
+    control_tx: &mpsc::Sender<ControlCommand>,
+) -> Result<()> {
+    if let Ok(mut guard) = desired_cfg.lock() {
+        *guard = next_cfg.clone();
+    }
+    if let Ok(mut guard) = runtime_cfg_toml.lock() {
+        *guard = next_cfg.to_toml_pretty()?;
+    }
+    if let Ok(mut state) = runtime_state.lock() {
+        state.begin_switch(&next_cfg);
+    }
+    control_tx
+        .send(ControlCommand::Reconfigure)
+        .context("failed to schedule runtime reconfiguration")
 }
 
 #[derive(Debug, Clone)]

--- a/src/app.rs
+++ b/src/app.rs
@@ -309,10 +309,11 @@ fn playlist_item_is_available(item: &we_core::playlist::PlaylistItem) -> bool {
 }
 
 fn persist_playlist_runtime(path: Option<&Path>, runtime: &PlaylistRuntime) {
-    let (Some(path), Some(snapshot)) = (path, runtime.snapshot()) else {
+    let Some(path) = path else {
         return;
     };
-    if let Err(error) = playlist::save_snapshot(path, &snapshot) {
+    let snapshot = runtime.snapshot();
+    if let Err(error) = playlist::persist_snapshot(path, snapshot.as_ref()) {
         warn!(error = %error, "failed to persist playlist runtime state");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -42,6 +42,11 @@ pub enum Command {
         #[arg(value_enum)]
         action: ControlAction,
     },
+    /// Control daemon-managed playlists
+    Playlist {
+        #[command(subcommand)]
+        action: PlaylistAction,
+    },
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -51,4 +56,16 @@ pub enum ControlAction {
     Resume,
     Reload,
     Status,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum PlaylistAction {
+    /// Start a named playlist
+    Play { name: String },
+    /// Advance to the next playable entry
+    Next,
+    /// Return to the previous playable entry
+    Previous,
+    /// Stop playlist progression while leaving the current wallpaper running
+    Stop,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,12 @@
-use std::{fs, path::Path};
+use std::{collections::BTreeMap, fs, path::Path};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use we_core::{config::HooksConfig, wallpaper::settings::WallpaperFillMode};
+use we_core::{
+    config::HooksConfig,
+    playlist::PlaylistConfig,
+    wallpaper::settings::{WallpaperFillMode, WallpaperSettings},
+};
 
 use crate::backend::{gnome::protocol, traits::BackendKind};
 
@@ -16,6 +20,10 @@ pub struct Config {
     pub renderer: RendererConfig,
     #[serde(default, skip_serializing_if = "HooksConfig::is_empty")]
     pub hooks: HooksConfig,
+    #[serde(default)]
+    pub wallpapers: BTreeMap<String, WallpaperSettings>,
+    #[serde(default)]
+    pub playlists: PlaylistConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -45,6 +45,25 @@ impl ControlCommand {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlaylistCommand {
+    Play(String),
+    Next,
+    Previous,
+    Stop,
+}
+
+impl PlaylistCommand {
+    fn request(&self) -> String {
+        match self {
+            Self::Play(name) => format!("playlist play {name}"),
+            Self::Next => "playlist next".to_string(),
+            Self::Previous => "playlist previous".to_string(),
+            Self::Stop => "playlist stop".to_string(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeLoopExit {
     Stop,
@@ -52,11 +71,12 @@ pub enum RuntimeLoopExit {
     Reconfigure,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum ControlRequest {
     Command(ControlCommand),
     Status,
     SwitchConfig(PathBuf),
+    Playlist(PlaylistCommand),
 }
 
 impl ControlRequest {
@@ -68,6 +88,21 @@ impl ControlRequest {
                 return None;
             }
             return Some(Self::SwitchConfig(PathBuf::from(path)));
+        }
+        if let Some(name) = trimmed.strip_prefix("playlist play ") {
+            let name = name.trim();
+            if name.is_empty() {
+                return None;
+            }
+            return Some(Self::Playlist(PlaylistCommand::Play(name.to_string())));
+        }
+        match trimmed.to_ascii_lowercase().as_str() {
+            "playlist next" => return Some(Self::Playlist(PlaylistCommand::Next)),
+            "playlist previous" | "playlist prev" => {
+                return Some(Self::Playlist(PlaylistCommand::Previous))
+            }
+            "playlist stop" => return Some(Self::Playlist(PlaylistCommand::Stop)),
+            _ => {}
         }
         let normalized = trimmed.to_ascii_lowercase();
         if normalized == "status" {
@@ -83,16 +118,18 @@ pub struct ControlServer {
 }
 
 impl ControlServer {
-    pub fn start<F, H, S>(
+    pub fn start<F, H, S, P>(
         tx: Sender<ControlCommand>,
         status_provider: F,
         command_handler: H,
         switch_config_handler: S,
+        playlist_handler: P,
     ) -> Result<Self>
     where
         F: Fn() -> String + Send + Sync + 'static,
         H: Fn(ControlCommand) -> Result<bool> + Send + Sync + 'static,
         S: Fn(&Path) -> Result<()> + Send + Sync + 'static,
+        P: Fn(PlaylistCommand) -> Result<()> + Send + Sync + 'static,
     {
         let instance_lock = acquire_instance_lock()?;
         let endpoint = default_endpoint()?;
@@ -101,6 +138,7 @@ impl ControlServer {
         let status_provider = std::sync::Arc::new(status_provider);
         let command_handler = std::sync::Arc::new(command_handler);
         let switch_config_handler = std::sync::Arc::new(switch_config_handler);
+        let playlist_handler = std::sync::Arc::new(playlist_handler);
         thread::spawn(move || {
             for stream in listener.incoming() {
                 let Ok(mut stream) = stream else {
@@ -120,6 +158,14 @@ impl ControlServer {
                         let _ = stream.write_all(status.as_bytes());
                     }
                     ControlRequest::SwitchConfig(path) => match switch_config_handler(&path) {
+                        Ok(()) => {
+                            let _ = stream.write_all(b"OK\n");
+                        }
+                        Err(err) => {
+                            let _ = stream.write_all(format!("ERR {err}\n").as_bytes());
+                        }
+                    },
+                    ControlRequest::Playlist(command) => match playlist_handler(command) {
                         Ok(()) => {
                             let _ = stream.write_all(b"OK\n");
                         }
@@ -179,6 +225,14 @@ pub fn request_running_config() -> Result<String> {
 
 pub fn send_switch_config(config_path: &Path) -> Result<()> {
     let response = send_request(&format!("switch-config {}", config_path.display()))?;
+    if response.trim_start().starts_with("ERR") {
+        return Err(anyhow!(response.trim().to_string()));
+    }
+    Ok(())
+}
+
+pub fn send_playlist_command(command: &PlaylistCommand) -> Result<()> {
+    let response = send_request(&command.request())?;
     if response.trim_start().starts_with("ERR") {
         return Err(anyhow!(response.trim().to_string()));
     }
@@ -349,4 +403,30 @@ fn acquire_instance_lock() -> Result<fs::File> {
 fn abstract_socket_name() -> Vec<u8> {
     let uid = unsafe { libc::geteuid() };
     format!("we-layerd.control.{uid}").into_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ControlRequest, PlaylistCommand};
+
+    #[test]
+    fn playlist_ipc_preserves_named_playlists_and_rejects_empty_names() {
+        assert_eq!(
+            ControlRequest::parse("playlist play Focus Session"),
+            Some(ControlRequest::Playlist(PlaylistCommand::Play("Focus Session".to_string())))
+        );
+        assert_eq!(ControlRequest::parse("playlist play    "), None);
+        assert_eq!(
+            ControlRequest::parse("playlist next"),
+            Some(ControlRequest::Playlist(PlaylistCommand::Next))
+        );
+        assert_eq!(
+            ControlRequest::parse("playlist previous"),
+            Some(ControlRequest::Playlist(PlaylistCommand::Previous))
+        );
+        assert_eq!(
+            ControlRequest::parse("playlist stop"),
+            Some(ControlRequest::Playlist(PlaylistCommand::Stop))
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ mod runtime;
 
 use anyhow::Result;
 use clap::Parser;
-use cli::{Cli, Command, ControlAction};
-use ipc::ControlCommand;
+use cli::{Cli, Command, ControlAction, PlaylistAction};
+use ipc::{ControlCommand, PlaylistCommand};
 
 fn main() -> Result<()> {
     logging::init();
@@ -42,5 +42,14 @@ fn main() -> Result<()> {
                 Ok(())
             }
         },
+        Command::Playlist { action } => {
+            let command = match action {
+                PlaylistAction::Play { name } => PlaylistCommand::Play(name),
+                PlaylistAction::Next => PlaylistCommand::Next,
+                PlaylistAction::Previous => PlaylistCommand::Previous,
+                PlaylistAction::Stop => PlaylistCommand::Stop,
+            };
+            ipc::send_playlist_command(&command)
+        }
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod control;
 pub(crate) mod input;
+pub(crate) mod playlist;
 pub(crate) mod renderer_session;
 pub(crate) mod status;

--- a/src/runtime/playlist.rs
+++ b/src/runtime/playlist.rs
@@ -21,7 +21,6 @@ pub(crate) enum AdvanceDirection {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PlaylistSelection {
-    pub(crate) playlist: String,
     pub(crate) index: usize,
     pub(crate) wallpaper_id: String,
     pub(crate) source: String,
@@ -270,7 +269,6 @@ impl PlaylistRuntime {
         let playlist_name = self.active_playlist.as_ref()?;
         let item = self.config.definitions.get(playlist_name)?.items.get(index)?;
         Some(PlaylistSelection {
-            playlist: playlist_name.clone(),
             index,
             wallpaper_id: item.wallpaper_id.clone(),
             source: item.source.clone(),
@@ -312,7 +310,19 @@ pub(crate) fn load_snapshot(path: &Path) -> Result<Option<PlaylistRuntimeSnapsho
         .with_context(|| format!("invalid playlist runtime state in {}", path.display()))
 }
 
-pub(crate) fn save_snapshot(path: &Path, snapshot: &PlaylistRuntimeSnapshot) -> Result<()> {
+pub(crate) fn persist_snapshot(
+    path: &Path,
+    snapshot: Option<&PlaylistRuntimeSnapshot>,
+) -> Result<()> {
+    let Some(snapshot) = snapshot else {
+        match fs::remove_file(path) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(error).with_context(|| format!("failed to remove {}", path.display()))
+            }
+        }
+    };
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
@@ -373,11 +383,14 @@ fn next_seed(seed: u64) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, Instant};
+    use std::{
+        fs,
+        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+    };
 
     use we_core::playlist::{Playlist, PlaylistConfig, PlaylistItem, PlaylistMode};
 
-    use super::{AdvanceDirection, PlaylistRuntime};
+    use super::{load_snapshot, persist_snapshot, AdvanceDirection, PlaylistRuntime};
 
     fn config(mode: PlaylistMode, ids: &[&str]) -> PlaylistConfig {
         let mut config = PlaylistConfig::default();
@@ -457,5 +470,26 @@ mod tests {
                 .wallpaper_id,
             "c"
         );
+    }
+
+    #[test]
+    fn clearing_playlist_runtime_state_prevents_a_stopped_playlist_from_restoring() {
+        let suffix = SystemTime::now().duration_since(UNIX_EPOCH).expect("system clock").as_nanos();
+        let root = std::env::temp_dir()
+            .join(format!("we-layerd-playlist-runtime-state-{}-{suffix}", std::process::id()));
+        let path = root.join("runtime.json");
+        let started = Instant::now();
+        let mut runtime = PlaylistRuntime::new(config(PlaylistMode::Repeat, &["a", "b"]), 23);
+        runtime.ensure_started(started).expect("playlist starts");
+        let snapshot = runtime.snapshot().expect("active runtime snapshot");
+
+        persist_snapshot(&path, Some(&snapshot)).expect("persist active playlist state");
+        assert!(load_snapshot(&path).expect("load active state").is_some());
+
+        runtime.stop();
+        persist_snapshot(&path, runtime.snapshot().as_ref()).expect("clear stopped playlist state");
+        assert_eq!(load_snapshot(&path).expect("load cleared state"), None);
+
+        let _ = fs::remove_dir_all(root);
     }
 }

--- a/src/runtime/playlist.rs
+++ b/src/runtime/playlist.rs
@@ -1,0 +1,461 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use we_core::playlist::{
+    Playlist, PlaylistConfig, PlaylistCursor, PlaylistCursorSnapshot, PlaylistItem,
+};
+use we_core::wallpaper::settings::{RenderResolution, WallpaperSettings};
+
+use crate::config::Config;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AdvanceDirection {
+    Next,
+    Previous,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PlaylistSelection {
+    pub(crate) playlist: String,
+    pub(crate) index: usize,
+    pub(crate) wallpaper_id: String,
+    pub(crate) source: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct PlaylistRuntimeSnapshot {
+    pub(crate) active_playlist: String,
+    pub(crate) cursor: PlaylistCursorSnapshot,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PlaylistRuntime {
+    config: PlaylistConfig,
+    active_playlist: Option<String>,
+    cursor: PlaylistCursor,
+    timer_started_at: Option<Instant>,
+    elapsed_before_pause: Duration,
+    paused: bool,
+    exhausted: bool,
+    seed: u64,
+}
+
+impl PlaylistRuntime {
+    pub(crate) fn new(config: PlaylistConfig, random_seed: u64) -> Self {
+        let active_playlist =
+            config.active.as_ref().filter(|name| config.definitions.contains_key(*name)).cloned();
+        let item_count = active_playlist
+            .as_deref()
+            .and_then(|name| config.definitions.get(name))
+            .map(|playlist| playlist.items.len())
+            .unwrap_or(0);
+        Self {
+            config,
+            active_playlist,
+            cursor: PlaylistCursor::new(item_count, random_seed),
+            timer_started_at: None,
+            elapsed_before_pause: Duration::ZERO,
+            paused: false,
+            exhausted: false,
+            seed: random_seed,
+        }
+    }
+
+    pub(crate) fn restore(
+        config: PlaylistConfig,
+        snapshot: PlaylistRuntimeSnapshot,
+        now: Instant,
+    ) -> Self {
+        let mut runtime = Self::new(config, snapshot.cursor.random_state);
+        if runtime.config.definitions.contains_key(&snapshot.active_playlist) {
+            runtime.active_playlist = Some(snapshot.active_playlist.clone());
+            runtime.config.active = Some(snapshot.active_playlist);
+            let item_count =
+                runtime.active_playlist_definition().map(|p| p.items.len()).unwrap_or(0);
+            runtime.cursor = PlaylistCursor::restore(item_count, snapshot.cursor);
+            if runtime.cursor.current_index().is_some() {
+                runtime.timer_started_at = Some(now);
+            }
+        }
+        runtime
+    }
+
+    pub(crate) fn configure(&mut self, config: PlaylistConfig, now: Instant) {
+        let previous_snapshot = self.snapshot();
+        let previous_active = self.active_playlist.clone();
+        self.config = config;
+        self.active_playlist = self
+            .config
+            .active
+            .as_ref()
+            .filter(|name| self.config.definitions.contains_key(*name))
+            .cloned();
+        self.exhausted = false;
+
+        if self.active_playlist == previous_active {
+            if let Some(snapshot) = previous_snapshot {
+                let item_count =
+                    self.active_playlist_definition().map(|p| p.items.len()).unwrap_or(0);
+                self.cursor = PlaylistCursor::restore(item_count, snapshot.cursor);
+                self.reset_timer(now);
+                return;
+            }
+        }
+
+        let item_count = self.active_playlist_definition().map(|p| p.items.len()).unwrap_or(0);
+        self.seed = next_seed(self.seed);
+        self.cursor = PlaylistCursor::new(item_count, self.seed);
+        self.reset_timer(now);
+    }
+
+    pub(crate) fn play(&mut self, name: &str, now: Instant) -> Result<PlaylistSelection, String> {
+        let Some(playlist) = self.config.definitions.get(name) else {
+            return Err(format!("playlist '{name}' does not exist"));
+        };
+        if playlist.items.is_empty() {
+            return Err(format!("playlist '{name}' is empty"));
+        }
+        self.active_playlist = Some(name.to_string());
+        self.config.active = Some(name.to_string());
+        self.seed = next_seed(self.seed);
+        self.cursor = PlaylistCursor::new(playlist.items.len(), self.seed);
+        self.exhausted = false;
+        let index =
+            self.cursor.start(playlist).ok_or_else(|| format!("playlist '{name}' is empty"))?;
+        self.reset_timer(now);
+        self.selection_at(index).ok_or_else(|| "playlist selection is invalid".to_string())
+    }
+
+    pub(crate) fn stop(&mut self) {
+        self.active_playlist = None;
+        self.config.active = None;
+        self.timer_started_at = None;
+        self.elapsed_before_pause = Duration::ZERO;
+        self.exhausted = false;
+    }
+
+    pub(crate) fn ensure_started(&mut self, now: Instant) -> Option<PlaylistSelection> {
+        if self.exhausted {
+            return None;
+        }
+        let playlist = self.active_playlist_definition()?.clone();
+        let index = self.cursor.start(&playlist)?;
+        if self.timer_started_at.is_none() && !self.paused {
+            self.timer_started_at = Some(now);
+        }
+        self.selection_at(index)
+    }
+
+    pub(crate) fn current_selection(&self) -> Option<PlaylistSelection> {
+        self.selection_at(self.cursor.current_index()?)
+    }
+
+    pub(crate) fn active_name(&self) -> Option<&str> {
+        self.active_playlist.as_deref()
+    }
+
+    pub(crate) fn due_selection<F>(
+        &mut self,
+        now: Instant,
+        playable: F,
+    ) -> Option<PlaylistSelection>
+    where
+        F: Fn(&PlaylistItem) -> bool,
+    {
+        if self.paused || self.exhausted {
+            return None;
+        }
+        let current = self.ensure_started(now)?;
+        let playlist = self.active_playlist_definition()?;
+        let duration = playlist.timed_duration_for(current.index)?;
+        if self.elapsed(now) < duration {
+            return None;
+        }
+        self.advance(AdvanceDirection::Next, now, playable)
+    }
+
+    pub(crate) fn advance<F>(
+        &mut self,
+        direction: AdvanceDirection,
+        now: Instant,
+        playable: F,
+    ) -> Option<PlaylistSelection>
+    where
+        F: Fn(&PlaylistItem) -> bool,
+    {
+        if self.exhausted && direction == AdvanceDirection::Next {
+            return None;
+        }
+        let playlist = self.active_playlist_definition()?.clone();
+        if self.cursor.current_index().is_none() {
+            self.cursor.start(&playlist)?;
+        }
+
+        let attempts = playlist.items.len().max(1);
+        for _ in 0..attempts {
+            let index = match direction {
+                AdvanceDirection::Next => self.cursor.next(&playlist),
+                AdvanceDirection::Previous => self.cursor.previous(&playlist),
+            };
+            let Some(index) = index else {
+                if direction == AdvanceDirection::Next {
+                    self.exhausted = true;
+                    self.timer_started_at = None;
+                }
+                return None;
+            };
+            let item = playlist.items.get(index)?;
+            if playable(item) {
+                self.exhausted = false;
+                self.reset_timer(now);
+                return self.selection_at(index);
+            }
+        }
+        None
+    }
+
+    pub(crate) fn pause(&mut self, now: Instant) {
+        if self.paused {
+            return;
+        }
+        if let Some(started) = self.timer_started_at.take() {
+            self.elapsed_before_pause += now.saturating_duration_since(started);
+        }
+        self.paused = true;
+    }
+
+    pub(crate) fn resume(&mut self, now: Instant) {
+        if !self.paused {
+            return;
+        }
+        self.paused = false;
+        if self.current_selection().is_some() && !self.exhausted {
+            self.timer_started_at = Some(now);
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> Option<PlaylistRuntimeSnapshot> {
+        Some(PlaylistRuntimeSnapshot {
+            active_playlist: self.active_playlist.clone()?,
+            cursor: self.cursor.snapshot(),
+        })
+    }
+
+    pub(crate) fn render_status_toml(&self) -> String {
+        let mut lines = vec!["[playlist_runtime]".to_string()];
+        match self.active_playlist.as_deref() {
+            Some(name) => lines.push(format!("active = {:?}", name)),
+            None => lines.push("active = false".to_string()),
+        }
+        if let Some(selection) = self.current_selection() {
+            lines.push(format!("index = {}", selection.index));
+            lines.push(format!("wallpaper_id = {:?}", selection.wallpaper_id));
+            lines.push(format!("source = {:?}", selection.source));
+        }
+        lines.push(format!("paused = {}", self.paused));
+        lines.push(format!("exhausted = {}", self.exhausted));
+        lines.join("\n")
+    }
+
+    fn active_playlist_definition(&self) -> Option<&Playlist> {
+        self.config.definitions.get(self.active_playlist.as_deref()?)
+    }
+
+    fn selection_at(&self, index: usize) -> Option<PlaylistSelection> {
+        let playlist_name = self.active_playlist.as_ref()?;
+        let item = self.config.definitions.get(playlist_name)?.items.get(index)?;
+        Some(PlaylistSelection {
+            playlist: playlist_name.clone(),
+            index,
+            wallpaper_id: item.wallpaper_id.clone(),
+            source: item.source.clone(),
+        })
+    }
+
+    fn elapsed(&self, now: Instant) -> Duration {
+        let live = self
+            .timer_started_at
+            .map(|started| now.saturating_duration_since(started))
+            .unwrap_or(Duration::ZERO);
+        self.elapsed_before_pause + live
+    }
+
+    fn reset_timer(&mut self, now: Instant) {
+        self.elapsed_before_pause = Duration::ZERO;
+        self.timer_started_at = if self.paused { None } else { Some(now) };
+    }
+}
+
+pub(crate) fn state_path_for_config(config_path: Option<&Path>) -> Option<PathBuf> {
+    config_path.map(|path| {
+        let mut state_path = path.as_os_str().to_os_string();
+        state_path.push(".playlist-state.json");
+        PathBuf::from(state_path)
+    })
+}
+
+pub(crate) fn load_snapshot(path: &Path) -> Result<Option<PlaylistRuntimeSnapshot>> {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to read {}", path.display()))
+        }
+    };
+    serde_json::from_str(&raw)
+        .map(Some)
+        .with_context(|| format!("invalid playlist runtime state in {}", path.display()))
+}
+
+pub(crate) fn save_snapshot(path: &Path, snapshot: &PlaylistRuntimeSnapshot) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let raw = serde_json::to_vec_pretty(snapshot).context("failed to serialize playlist state")?;
+    let mut temporary = path.as_os_str().to_os_string();
+    temporary.push(format!(".{}.tmp", std::process::id()));
+    let temporary = PathBuf::from(temporary);
+    fs::write(&temporary, raw)
+        .with_context(|| format!("failed to write {}", temporary.display()))?;
+    fs::rename(&temporary, path).with_context(|| format!("failed to replace {}", path.display()))
+}
+
+pub(crate) fn random_seed() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos() as u64)
+        .unwrap_or(0x9e37_79b9_7f4a_7c15)
+}
+
+pub(crate) fn apply_selection_to_config(
+    config: &mut Config,
+    selection: &PlaylistSelection,
+) -> Result<()> {
+    config.renderer.source = selection.source.clone();
+    let wallpaper = config
+        .wallpapers
+        .get(&selection.wallpaper_id)
+        .cloned()
+        .unwrap_or_else(WallpaperSettings::default);
+    config.renderer.fps = wallpaper.fps.clamp(1, 360);
+    config.renderer.speed = wallpaper.speed;
+    config.renderer.volume = wallpaper.volume;
+    config.renderer.muted = wallpaper.muted;
+    config.renderer.fill_mode = wallpaper.fill_mode;
+    config.renderer.rotation_degrees = wallpaper.rotation_degrees.degrees();
+    match wallpaper.render_resolution {
+        RenderResolution::Automatic => {
+            config.renderer.render_width = None;
+            config.renderer.render_height = None;
+        }
+        RenderResolution::Fixed { width, height } => {
+            config.renderer.render_width = Some(width.max(1));
+            config.renderer.render_height = Some(height.max(1));
+        }
+    }
+    config.renderer.options_json = Some(we_core::config::merge_scene_source_options(
+        config.renderer.options_json.as_deref(),
+        Some(wallpaper.user_properties),
+        config.general.force_scene_audio_loop,
+    )?);
+    Ok(())
+}
+
+fn next_seed(seed: u64) -> u64 {
+    seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use we_core::playlist::{Playlist, PlaylistConfig, PlaylistItem, PlaylistMode};
+
+    use super::{AdvanceDirection, PlaylistRuntime};
+
+    fn config(mode: PlaylistMode, ids: &[&str]) -> PlaylistConfig {
+        let mut config = PlaylistConfig::default();
+        config.active = Some("daily".to_string());
+        config.definitions.insert(
+            "daily".to_string(),
+            Playlist {
+                mode,
+                default_duration_ms: 1_000,
+                items: ids
+                    .iter()
+                    .map(|id| PlaylistItem {
+                        wallpaper_id: (*id).to_string(),
+                        source: format!("/wallpapers/{id}"),
+                        duration_ms: None,
+                    })
+                    .collect(),
+            },
+        );
+        config
+    }
+
+    #[test]
+    fn timer_freezes_while_paused_and_resumes_from_the_same_elapsed_time() {
+        let started = Instant::now();
+        let mut runtime = PlaylistRuntime::new(config(PlaylistMode::Repeat, &["a", "b"]), 5);
+        runtime.ensure_started(started).expect("playlist starts");
+
+        runtime.pause(started + Duration::from_millis(400));
+        assert!(runtime.due_selection(started + Duration::from_secs(10), |_| true).is_none());
+
+        runtime.resume(started + Duration::from_secs(10));
+        assert!(runtime.due_selection(started + Duration::from_millis(10_599), |_| true).is_none());
+        assert_eq!(
+            runtime
+                .due_selection(started + Duration::from_millis(10_600), |_| true)
+                .expect("remaining 600ms expires")
+                .wallpaper_id,
+            "b"
+        );
+    }
+
+    #[test]
+    fn progression_skips_unavailable_wallpapers_without_ending_the_playlist() {
+        let started = Instant::now();
+        let mut runtime =
+            PlaylistRuntime::new(config(PlaylistMode::Repeat, &["a", "missing", "c"]), 9);
+        runtime.ensure_started(started).expect("playlist starts");
+
+        let selection = runtime
+            .advance(AdvanceDirection::Next, started, |item| item.wallpaper_id != "missing")
+            .expect("a later playable item exists");
+        assert_eq!(selection.wallpaper_id, "c");
+    }
+
+    #[test]
+    fn restored_snapshot_resumes_at_the_same_item_with_a_fresh_timer() {
+        let started = Instant::now();
+        let playlist_config = config(PlaylistMode::Repeat, &["a", "b", "c"]);
+        let mut runtime = PlaylistRuntime::new(playlist_config.clone(), 17);
+        runtime.ensure_started(started).expect("playlist starts");
+        runtime
+            .advance(AdvanceDirection::Next, started + Duration::from_secs(1), |_| true)
+            .expect("advance to second item");
+        let snapshot = runtime.snapshot().expect("runtime snapshot");
+
+        let restored_at = started + Duration::from_secs(30);
+        let mut restored = PlaylistRuntime::restore(playlist_config, snapshot, restored_at);
+        assert_eq!(restored.current_selection().expect("current item").wallpaper_id, "b");
+        assert!(restored
+            .due_selection(restored_at + Duration::from_millis(999), |_| true)
+            .is_none());
+        assert_eq!(
+            restored
+                .due_selection(restored_at + Duration::from_millis(1_000), |_| true)
+                .expect("fresh timer expires")
+                .wallpaper_id,
+            "c"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add persistent named playlist definitions with ordered, repeat, shuffle-bag, and manual modes
- move playlist timing and progression into the daemon with pause/resume, missing-item skipping, next/previous, runtime status, and restart cursor restoration
- add playlist IPC/CLI controls and configuration documentation

## Validation
- `cargo fmt --all`
- `git diff --check`
- tests/build were not executed in this phase