### PR TITLE
Fix v0.2.7 release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
             binutils build-essential bzip2 ca-certificates cmake curl debhelper \
             devscripts dpkg-dev fakeroot file git libasound2-dev libdrm-dev \
-            libfontconfig1-dev libfreetype-dev libgl-dev \
+            libfontconfig1-dev libfreetype-dev libgl-dev libpulse-dev \
             libgstreamer-plugins-bad1.0-dev libgstreamer-plugins-base1.0-dev \
             libgstreamer1.0-dev libgtk-3-dev liblz4-dev libpango1.0-dev \
             libva-dev libvulkan-dev libwayland-dev libxdo-dev \
@@ -380,7 +380,7 @@ jobs:
             gstreamer1-plugins-base-devel gtk3-devel libatomic libdrm-devel \
             libva-devel libxdo-devel libxkbcommon-devel lz4-devel \
             mesa-libGL-devel pango-devel patchelf pkgconf-pkg-config \
-            rpm-build rust tar vulkan-headers vulkan-loader-devel \
+            pulseaudio-libs-devel rpm-build rust tar vulkan-headers vulkan-loader-devel \
             wayland-devel wayland-protocols-devel xz
 
       - name: Check out source and submodules
@@ -454,8 +454,19 @@ jobs:
           cargo --version
           rpmbuild --version
 
+      - name: Fetch locked Rust dependencies
+        shell: bash
+        env:
+          CARGO_NET_RETRY: "10"
+          CARGO_HTTP_TIMEOUT: "60"
+        run: |
+          set -euo pipefail
+          timeout --signal=TERM --kill-after=30s 8m cargo fetch --locked
+
       - name: Build RPM and SRPM
         shell: bash
+        env:
+          CARGO_NET_OFFLINE: "true"
         run: package/fedora/build.sh
 
       - name: Verify package artifacts

--- a/package/fedora/we-layerd.spec
+++ b/package/fedora/we-layerd.spec
@@ -36,6 +36,7 @@ BuildRequires:  mesa-libGL-devel
 BuildRequires:  pango-devel
 BuildRequires:  patchelf
 BuildRequires:  pkgconf-pkg-config
+BuildRequires:  pulseaudio-libs-devel
 BuildRequires:  rust
 BuildRequires:  vulkan-headers
 BuildRequires:  vulkan-loader-devel

--- a/package/ubuntu/debian/control
+++ b/package/ubuntu/debian/control
@@ -19,6 +19,7 @@ Build-Depends:
  libgtk-3-dev,
  liblz4-dev,
  libpango1.0-dev,
+ libpulse-dev,
  libva-dev,
  libvulkan-dev,
  libwayland-dev,


### PR DESCRIPTION
Fix the two failures from the v0.2.7 release run:

- Add the missing PulseAudio development dependency to Ubuntu and Fedora package builds.
- Explicitly fetch locked Rust sources before Fedora source vendoring, then force the RPM/SRPM build offline so packaging no longer depends on crates.io access.

Validation:
- `git diff --check`
- release workflow YAML parses successfully
- `CARGO_NET_OFFLINE=true package/common/prepare-source.sh ...` succeeds and vendors `error-code-3.3.2`