### PR TITLE
feat(gui): 增加壁纸库手动刷新

### DIFF
--- a/apps/we-gui/src/app/state.rs
+++ b/apps/we-gui/src/app/state.rs
@@ -140,6 +140,7 @@ impl Drop for App {
 #[derive(Debug, Clone)]
 pub(crate) enum Message {
     AutoScan,
+    RefreshLibrary,
     ScanCompleted(u64, Result<Vec<WallpaperEntry>, String>),
     GifLoaded { generation: u64, path: PathBuf, result: Result<Vec<GifFrame>, String> },
     GifTick,

--- a/apps/we-gui/src/app/update.rs
+++ b/apps/we-gui/src/app/update.rs
@@ -37,7 +37,9 @@ const MAX_CONCURRENT_GIF_DECODES: usize = 2;
 
 pub(crate) fn update(app: &mut App, message: Message) -> Task<Message> {
     match message {
-        Message::AutoScan => queue_library_scan(app, app.ui_settings.workshop_path.clone()),
+        Message::AutoScan | Message::RefreshLibrary => {
+            queue_library_scan(app, app.ui_settings.workshop_path.clone())
+        }
         Message::ScanCompleted(generation, result) => finish_library_scan(app, generation, result),
         Message::SelectWallpaper(index) => {
             if !select_wallpaper(app, index, true) {

--- a/apps/we-gui/src/domain/i18n/en.rs
+++ b/apps/we-gui/src/domain/i18n/en.rs
@@ -3,6 +3,7 @@ use super::Text;
 pub(super) fn text(key: Text) -> &'static str {
     match key {
         Text::Wallpapers => "Wallpapers",
+        Text::RefreshLibrary => "Refresh",
         Text::SearchWallpapers => "Search wallpapers",
         Text::NoMatchingWallpapers => "No wallpapers match your search and filters.",
         Text::OpenSettings => "Open settings",

--- a/apps/we-gui/src/domain/i18n/mod.rs
+++ b/apps/we-gui/src/domain/i18n/mod.rs
@@ -154,6 +154,7 @@ impl fmt::Display for Language {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Text {
     Wallpapers,
+    RefreshLibrary,
     SearchWallpapers,
     NoMatchingWallpapers,
     OpenSettings,

--- a/apps/we-gui/src/domain/i18n/zh_hans.rs
+++ b/apps/we-gui/src/domain/i18n/zh_hans.rs
@@ -3,6 +3,7 @@ use super::Text;
 pub(super) fn text(key: Text) -> &'static str {
     match key {
         Text::Wallpapers => "壁纸",
+        Text::RefreshLibrary => "刷新壁纸",
         Text::SearchWallpapers => "搜索壁纸",
         Text::NoMatchingWallpapers => "没有符合搜索和筛选条件的壁纸。",
         Text::OpenSettings => "打开设置",

--- a/apps/we-gui/src/ui/library.rs
+++ b/apps/we-gui/src/ui/library.rs
@@ -87,6 +87,12 @@ pub(crate) fn view(app: &App) -> Element<'_, Message> {
         .spacing(2)
         .width(Fill),
         container(
+            button(text(format!("↻  {}", language.text(Text::RefreshLibrary))).size(16))
+                .on_press(Message::RefreshLibrary)
+                .style(top_bar_button_style),
+        )
+        .id("library.refresh"),
+        container(
             button(text(format!("☷  {}", language.text(Text::Playlists))).size(16))
                 .on_press(Message::PlaylistsPressed)
                 .style(top_bar_button_style),


### PR DESCRIPTION
## 概要

为 `we-gui` 壁纸库增加手动刷新功能，方便在 Wallpaper Engine 创意工坊新增或删除壁纸后直接更新列表。

## 变更内容

- 在壁纸库顶部增加“刷新壁纸”按钮。
- 点击后重新扫描当前 Workshop 路径。
- 扫描完成后沿用现有逻辑更新列表、搜索结果、类型筛选和 GIF 预览。
- 增加英文和简体中文本地化文本。
- 使用现有扫描调度器，重复点击不会并发启动多个扫描任务。

## 验证

- `cargo fmt --all -- --check` 通过。
- `git diff --check` 通过。
- `cargo test -p we-gui` 在链接阶段受环境依赖阻塞：系统缺少 `libxdo`（`-lxdo`）。

## 分支关系

- `feat/gui-wallpaper-refresh` 已改为直接基于上游 `main`（本地跟踪的 `origin/main`）。
- 该 PR 只包含壁纸刷新提交，不包含尚未合并的 `perf: cap wallpaper FPS globally`。
- 为本地同时使用两项改动，保留了本地分支 `local/perf-and-refresh`，它基于本地 `main`（包含性能优化）并叠加了本次刷新功能。
