### PR TITLE
fix(gui): 退出后保留壁纸运行

### DIFF
--- a/apps/we-gui/src/app/mod.rs
+++ b/apps/we-gui/src/app/mod.rs
@@ -197,7 +197,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn dropping_gui_stops_layerd() {
+    fn exiting_gui_keeps_layerd_running() {
         let _lock = ENV_LOCK.lock().expect("environment lock");
         let suffix = SystemTime::now().duration_since(UNIX_EPOCH).expect("system clock").as_nanos();
         let temp = std::env::temp_dir().join(format!("we-gui-exit-{suffix}"));
@@ -215,7 +215,7 @@ mod tests {
         std::env::set_var("PATH", &temp);
         std::env::set_var("WE_GUI_TEST_LOG", &log);
 
-        let app = App {
+        let mut app = App {
             entries: Vec::new(),
             selected_id: None,
             selected_schema: UserPropertySchema { entries: Vec::new() },
@@ -272,6 +272,7 @@ mod tests {
             legacy_shuffle: legacy_shuffle(),
             playlist_migration_completed: true,
         };
+        let _task = update::update(&mut app, Message::ExitRequested);
         drop(app);
 
         match old_path {
@@ -283,8 +284,11 @@ mod tests {
             None => std::env::remove_var("WE_GUI_TEST_LOG"),
         }
 
-        let commands = fs::read_to_string(&log).expect("read fake command log");
-        assert!(commands.lines().any(|line| line == "ctl stop"));
+        let commands = fs::read_to_string(&log).unwrap_or_default();
+        assert!(
+            commands.trim().is_empty(),
+            "GUI exit must not stop the daemon, got commands: {commands:?}"
+        );
         fs::remove_dir_all(temp).expect("remove test directory");
     }
 

--- a/apps/we-gui/src/app/state.rs
+++ b/apps/we-gui/src/app/state.rs
@@ -131,12 +131,6 @@ impl App {
     }
 }
 
-impl Drop for App {
-    fn drop(&mut self) {
-        let _ = self.shutdown_runtime();
-    }
-}
-
 #[derive(Debug, Clone)]
 pub(crate) enum Message {
     AutoScan,

--- a/apps/we-gui/src/app/update.rs
+++ b/apps/we-gui/src/app/update.rs
@@ -777,10 +777,7 @@ pub(crate) fn update(app: &mut App, message: Message) -> Task<Message> {
     }
 }
 
-fn exit_application(app: &mut App) -> Task<Message> {
-    if !app.shutdown_runtime() {
-        eprintln!("failed to stop daemon while exiting we-gui");
-    }
+fn exit_application(_app: &mut App) -> Task<Message> {
     iced::exit()
 }
 

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -41,8 +41,10 @@ That persistence currently applies to the global playlist runtime. Output-scoped
 own independent in-memory cursors and timers.
 
 The GUI **Playlists** sidebar controls these commands directly. Closing the wallpaper library window
-does not drive playlist timing: progression remains daemon-owned. GUI playlist edits are persisted in
-the normal configuration and a running edited playlist is reloaded by the daemon.
+does not drive playlist timing: progression remains daemon-owned. Exiting `we-gui`, including the
+tray **Quit** action, also leaves the daemon running; use the GUI **Stop** action or `we-layerd ctl
+stop` when the wallpaper runtime should stop. GUI playlist edits are persisted in the normal
+configuration and a running edited playlist is reloaded by the daemon.
 
 Other commands:
 ```bash

--- a/docs/ADVANCED.zh-CN.md
+++ b/docs/ADVANCED.zh-CN.md
@@ -38,6 +38,9 @@ we-layerd playlist stop --output DP-1
 全局播放列表位置会在守护进程重启后恢复；per-output 播放列表各自维护独立的内存
 cursor 与计时器。
 
+退出 `we-gui`（包括托盘中的“退出”操作）不会停止守护进程；需要停止壁纸时，请使用 GUI
+中的“停止”操作或执行 `we-layerd ctl stop`。
+
 其他命令：
 ```bash
 we-layerd doctor


### PR DESCRIPTION
如果已经开启了daemon，再打开 we-gui 去切换壁纸，然后再退出 we-gui，会连带着 daemon 一起退出。

该 PR 修复了这个问题