### PR TITLE
fix(gui): separate GUI and wallpaper daemon lifecycle

### DIFF
--- a/apps/we-gui/src/app/init.rs
+++ b/apps/we-gui/src/app/init.rs
@@ -132,6 +132,9 @@ pub(crate) fn initialize() -> (App, Task<Message>) {
             language,
             preferences_path,
             runtime_status: RuntimeStatus::DaemonNotRunning,
+            autostart_enabled: false,
+            autostart_pending: true,
+            autostart_error: None,
             preferences_generation: 0,
             playlist_selected,
             playlist_new_name_input: String::new(),
@@ -156,6 +159,10 @@ pub(crate) fn initialize() -> (App, Task<Message>) {
         Task::batch(vec![
             Task::done(Message::AutoScan),
             Task::perform(crate::services::runtime::fetch_outputs(), Message::OutputsLoaded),
+            Task::perform(
+                async { crate::services::autostart::is_enabled() },
+                Message::AutostartStatusLoaded,
+            ),
             window::open(window::Settings::default()).1.map(Message::WindowOpened),
         ]),
     )

--- a/apps/we-gui/src/app/mod.rs
+++ b/apps/we-gui/src/app/mod.rs
@@ -153,6 +153,9 @@ mod tests {
             language: Language::English,
             preferences_path: Some(preferences_path.clone()),
             runtime_status: RuntimeStatus::DaemonNotRunning,
+            autostart_enabled: false,
+            autostart_pending: false,
+            autostart_error: None,
             preferences_generation: 0,
             playlist_selected: None,
             playlist_new_name_input: String::new(),
@@ -197,7 +200,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn dropping_gui_stops_layerd() {
+    fn dropping_gui_leaves_unowned_layerd_running() {
         let _lock = ENV_LOCK.lock().expect("environment lock");
         let suffix = SystemTime::now().duration_since(UNIX_EPOCH).expect("system clock").as_nanos();
         let temp = std::env::temp_dir().join(format!("we-gui-exit-{suffix}"));
@@ -257,6 +260,9 @@ mod tests {
             language: Language::English,
             preferences_path: None,
             runtime_status: RuntimeStatus::DaemonNotRunning,
+            autostart_enabled: false,
+            autostart_pending: false,
+            autostart_error: None,
             preferences_generation: 0,
             playlist_selected: None,
             playlist_new_name_input: String::new(),
@@ -283,8 +289,69 @@ mod tests {
             None => std::env::remove_var("WE_GUI_TEST_LOG"),
         }
 
-        let commands = fs::read_to_string(&log).expect("read fake command log");
-        assert!(commands.lines().any(|line| line == "ctl stop"));
+        let commands = fs::read_to_string(&log).unwrap_or_default();
+        assert!(commands.trim().is_empty());
+        fs::remove_dir_all(temp).expect("remove test directory");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runtime_restart_preserves_systemd_ownership() {
+        let _lock = ENV_LOCK.lock().expect("environment lock");
+        let suffix = SystemTime::now().duration_since(UNIX_EPOCH).expect("system clock").as_nanos();
+        let temp = std::env::temp_dir().join(format!("we-gui-systemd-restart-{suffix}"));
+        let systemctl = temp.join("systemctl");
+        let layerd = temp.join("we-layerd");
+        let systemctl_log = temp.join("systemctl.log");
+        let layerd_log = temp.join("layerd.log");
+        fs::create_dir_all(&temp).expect("create test directory");
+        fs::write(
+            &systemctl,
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$WE_GUI_SYSTEMCTL_LOG\"\nif [ \"$1 $2 $3\" = \"--user is-active we-layerd.service\" ]; then printf 'active\\n'; exit 0; fi\nif [ \"$1 $2 $3\" = \"--user restart we-layerd.service\" ]; then exit 0; fi\nexit 1\n",
+        )
+        .expect("write fake systemctl");
+        fs::write(&layerd, "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$WE_GUI_LAYERD_LOG\"\nexit 1\n")
+            .expect("write fake we-layerd");
+        for command in [&systemctl, &layerd] {
+            let mut permissions =
+                fs::metadata(command).expect("fake command metadata").permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(command, permissions).expect("make fake command executable");
+        }
+
+        let old_path = std::env::var_os("PATH");
+        let old_systemctl_log = std::env::var_os("WE_GUI_SYSTEMCTL_LOG");
+        let old_layerd_log = std::env::var_os("WE_GUI_LAYERD_LOG");
+        std::env::set_var("PATH", &temp);
+        std::env::set_var("WE_GUI_SYSTEMCTL_LOG", &systemctl_log);
+        std::env::set_var("WE_GUI_LAYERD_LOG", &layerd_log);
+
+        let mut owned_child = None;
+        let replacement =
+            crate::services::runtime::restart(&temp.join("config.toml"), &mut owned_child)
+                .expect("restart systemd-managed daemon");
+
+        match old_path {
+            Some(path) => std::env::set_var("PATH", path),
+            None => std::env::remove_var("PATH"),
+        }
+        match old_systemctl_log {
+            Some(value) => std::env::set_var("WE_GUI_SYSTEMCTL_LOG", value),
+            None => std::env::remove_var("WE_GUI_SYSTEMCTL_LOG"),
+        }
+        match old_layerd_log {
+            Some(value) => std::env::set_var("WE_GUI_LAYERD_LOG", value),
+            None => std::env::remove_var("WE_GUI_LAYERD_LOG"),
+        }
+
+        assert!(replacement.is_none());
+        assert!(owned_child.is_none());
+        let systemctl_commands = fs::read_to_string(&systemctl_log).expect("read systemctl log");
+        assert_eq!(
+            systemctl_commands.lines().collect::<Vec<_>>(),
+            ["--user is-active we-layerd.service", "--user restart we-layerd.service"]
+        );
+        assert!(!layerd_log.exists());
         fs::remove_dir_all(temp).expect("remove test directory");
     }
 
@@ -313,8 +380,9 @@ mod tests {
         std::env::set_var("WE_GUI_TEST_LOG", &log);
 
         let mut owned_child = None;
-        let mut replacement =
-            crate::services::runtime::restart(&config, &mut owned_child).expect("restart daemon");
+        let mut replacement = crate::services::runtime::restart(&config, &mut owned_child)
+            .expect("restart daemon")
+            .expect("direct restart should return an owned child");
         std::thread::sleep(std::time::Duration::from_millis(50));
         let _ = replacement.kill();
         let _ = replacement.wait();

--- a/apps/we-gui/src/app/state.rs
+++ b/apps/we-gui/src/app/state.rs
@@ -65,6 +65,9 @@ pub(crate) struct App {
     pub language: Language,
     pub preferences_path: Option<PathBuf>,
     pub runtime_status: RuntimeStatus,
+    pub autostart_enabled: bool,
+    pub autostart_pending: bool,
+    pub autostart_error: Option<String>,
     pub preferences_generation: u64,
     pub playlist_selected: Option<String>,
     pub playlist_new_name_input: String,
@@ -121,6 +124,16 @@ impl App {
         stopped
     }
 
+    pub(crate) fn shutdown_owned_runtime(&mut self) -> bool {
+        if self.runtime_shutdown {
+            return true;
+        }
+        self.runtime_shutdown = true;
+        let stopped = crate::services::runtime::stop_owned(&mut self.runtime_child);
+        self.clear_playback_state();
+        stopped
+    }
+
     pub(crate) fn clear_playback_state(&mut self) {
         self.playback_running = false;
         self.playback_paused = false;
@@ -133,7 +146,7 @@ impl App {
 
 impl Drop for App {
     fn drop(&mut self) {
-        let _ = self.shutdown_runtime();
+        let _ = self.shutdown_owned_runtime();
     }
 }
 
@@ -173,6 +186,9 @@ pub(crate) enum Message {
     FullscreenRuleSelected(we_core::config::RuntimeRuleAction),
     PreferDmabufToggled(bool),
     AllowShmFallbackToggled(bool),
+    AutostartStatusLoaded(Result<bool, String>),
+    AutostartToggled(bool),
+    AutostartUpdated { enabled: bool, result: Result<(), String> },
     LanguageSelected(Language),
     PreferencesSaved { generation: u64, result: Result<(), String> },
     Detail(DetailMessage),

--- a/apps/we-gui/src/app/update.rs
+++ b/apps/we-gui/src/app/update.rs
@@ -23,7 +23,7 @@ use crate::{
         ui_state::{AnimatedPreview, Sidebar},
     },
     platform::tray,
-    services::{config, preferences, runtime, wallpaper as wallpaper_service},
+    services::{autostart, config, preferences, runtime, wallpaper as wallpaper_service},
     ui::sidebar::detail as wallpaper_detail,
 };
 
@@ -101,7 +101,13 @@ pub(crate) fn update(app: &mut App, message: Message) -> Task<Message> {
             };
             app.show_settings = app.sidebar == Some(Sidebar::Settings);
             if app.show_settings {
-                return Task::perform(runtime::fetch_status(), Message::StatusLoaded);
+                return Task::batch(vec![
+                    Task::perform(runtime::fetch_status(), Message::StatusLoaded),
+                    Task::perform(
+                        async { autostart::is_enabled() },
+                        Message::AutostartStatusLoaded,
+                    ),
+                ]);
             }
             Task::none()
         }
@@ -264,6 +270,40 @@ pub(crate) fn update(app: &mut App, message: Message) -> Task<Message> {
         Message::AllowShmFallbackToggled(value) => {
             app.ui_settings.allow_shm_fallback = value;
             super::settings::sync(app);
+            Task::none()
+        }
+        Message::AutostartStatusLoaded(result) => {
+            app.autostart_pending = false;
+            match result {
+                Ok(enabled) => {
+                    app.autostart_enabled = enabled;
+                    app.autostart_error = None;
+                }
+                Err(error) => app.autostart_error = Some(error),
+            }
+            Task::none()
+        }
+        Message::AutostartToggled(enabled) => {
+            if app.autostart_pending {
+                return Task::none();
+            }
+            app.autostart_pending = true;
+            app.autostart_error = None;
+            let config_path = app.config_path.clone();
+            Task::perform(
+                async move { autostart::set_enabled(enabled, &config_path) },
+                move |result| Message::AutostartUpdated { enabled, result },
+            )
+        }
+        Message::AutostartUpdated { enabled, result } => {
+            app.autostart_pending = false;
+            match result {
+                Ok(()) => {
+                    app.autostart_enabled = enabled;
+                    app.autostart_error = None;
+                }
+                Err(error) => app.autostart_error = Some(error),
+            }
             Task::none()
         }
         Message::LanguageSelected(language) => {
@@ -778,8 +818,8 @@ pub(crate) fn update(app: &mut App, message: Message) -> Task<Message> {
 }
 
 fn exit_application(app: &mut App) -> Task<Message> {
-    if !app.shutdown_runtime() {
-        eprintln!("failed to stop daemon while exiting we-gui");
+    if !app.shutdown_owned_runtime() {
+        eprintln!("failed to stop GUI-owned daemon while exiting we-gui");
     }
     iced::exit()
 }
@@ -1095,8 +1135,7 @@ fn reload_running_config(app: &mut App) -> Result<(), String> {
         return Ok(());
     }
 
-    let child = runtime::restart(&app.config_path, &mut app.runtime_child)?;
-    app.runtime_child = Some(child);
+    app.runtime_child = runtime::restart(&app.config_path, &mut app.runtime_child)?;
     Ok(())
 }
 
@@ -1352,7 +1391,7 @@ fn play_selected_playlist(app: &mut App) -> Task<Message> {
 
         return match runtime::restart(&app.config_path, &mut app.runtime_child) {
             Ok(child) => {
-                app.runtime_child = Some(child);
+                app.runtime_child = child;
                 app.playback_running = true;
                 app.playback_paused = false;
                 app.runtime_playlist_active = Some(name);
@@ -1401,7 +1440,7 @@ fn synchronize_migrated_playlist_with_running_daemon(app: &mut App) {
 
     match runtime::restart(&app.config_path, &mut app.runtime_child) {
         Ok(child) => {
-            app.runtime_child = Some(child);
+            app.runtime_child = child;
             app.runtime_shutdown = false;
             app.playback_running = true;
             app.playback_paused = false;
@@ -1610,14 +1649,14 @@ fn play_selected(app: &mut App, start: PlaybackStart) -> Task<Message> {
 
     let spawn = match start {
         PlaybackStart::SwitchOrStart => {
-            runtime::start(&app.config_path).map_err(|error| error.to_string())
+            runtime::start(&app.config_path).map(Some).map_err(|error| error.to_string())
         }
         PlaybackStart::Restart => runtime::restart(&app.config_path, &mut app.runtime_child),
     };
 
     match spawn {
         Ok(child) => {
-            app.runtime_child = Some(child);
+            app.runtime_child = child;
             app.runtime_status = RuntimeStatus::StartedDaemon;
             mark_selected_wallpaper_running(app);
         }
@@ -1687,7 +1726,7 @@ fn start_or_reconfigure_multi_output(app: &mut App) -> Task<Message> {
         }
         return match runtime::restart(&app.config_path, &mut app.runtime_child) {
             Ok(child) => {
-                app.runtime_child = Some(child);
+                app.runtime_child = child;
                 app.playback_running = true;
                 app.playback_paused = false;
                 app.runtime_status = RuntimeStatus::StartedDaemon;

--- a/apps/we-gui/src/app/view.rs
+++ b/apps/we-gui/src/app/view.rs
@@ -59,9 +59,14 @@ pub(crate) fn daemon_view(app: &App, _window: window::Id) -> Element<'_, Message
 
 fn sidebar_view(app: &App, sidebar: Sidebar) -> Element<'_, Message> {
     match sidebar {
-        Sidebar::Settings => {
-            settings::build_settings_overlay(&app.ui_settings, app.language, &app.runtime_status)
-        }
+        Sidebar::Settings => settings::build_settings_overlay(
+            &app.ui_settings,
+            app.language,
+            &app.runtime_status,
+            app.autostart_enabled,
+            app.autostart_pending,
+            app.autostart_error.as_deref(),
+        ),
         Sidebar::Playlist => playlist::view(app),
         Sidebar::Profile => profile::view(app),
         Sidebar::Detail => match app

--- a/apps/we-gui/src/domain/i18n/en.rs
+++ b/apps/we-gui/src/domain/i18n/en.rs
@@ -68,6 +68,10 @@ pub(super) fn text(key: Text) -> &'static str {
         Text::ScaleCover => "Cover",
         Text::ScaleStretch => "Stretch",
         Text::Behaviour => "Behaviour",
+        Text::StartOnLogin => "Start wallpaper on login",
+        Text::StartOnLoginDescription => {
+            "Enables the systemd user service for future graphical logins and applies the saved wallpaper configuration."
+        }
         Text::EnableWallpaperInput => "Enable wallpaper input",
         Text::ForceSceneAudioLoop => "Force loop scene audio",
         Text::ForceSceneAudioLoopDescription => {

--- a/apps/we-gui/src/domain/i18n/mod.rs
+++ b/apps/we-gui/src/domain/i18n/mod.rs
@@ -219,6 +219,8 @@ pub(crate) enum Text {
     ScaleCover,
     ScaleStretch,
     Behaviour,
+    StartOnLogin,
+    StartOnLoginDescription,
     EnableWallpaperInput,
     ForceSceneAudioLoop,
     ForceSceneAudioLoopDescription,

--- a/apps/we-gui/src/domain/i18n/zh_hans.rs
+++ b/apps/we-gui/src/domain/i18n/zh_hans.rs
@@ -68,6 +68,10 @@ pub(super) fn text(key: Text) -> &'static str {
         Text::ScaleCover => "覆盖",
         Text::ScaleStretch => "拉伸",
         Text::Behaviour => "行为",
+        Text::StartOnLogin => "登录时自动启动壁纸",
+        Text::StartOnLoginDescription => {
+            "为后续图形会话启用 systemd 用户服务，并自动应用已保存的壁纸配置。"
+        }
         Text::EnableWallpaperInput => "启用壁纸输入",
         Text::ForceSceneAudioLoop => "强制循环场景音频",
         Text::ForceSceneAudioLoopDescription => {

--- a/apps/we-gui/src/services/autostart.rs
+++ b/apps/we-gui/src/services/autostart.rs
@@ -1,0 +1,230 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+const UNIT_NAME: &str = "we-layerd.service";
+const MANAGED_UNIT_MARKER: &str =
+    "# Managed by we-gui. Do not edit while using the GUI autostart setting.";
+
+pub fn is_enabled() -> Result<bool, String> {
+    let output = systemctl(&["is-enabled", UNIT_NAME])?;
+    if output.status.success() {
+        return Ok(true);
+    }
+    if unit_missing(&output) {
+        return Ok(false);
+    }
+
+    match stdout_state(&output).as_str() {
+        "disabled" | "masked" | "static" | "indirect" => Ok(false),
+        _ => Err(output_error("failed to query systemd user autostart state", &output)),
+    }
+}
+
+pub fn set_enabled(enabled: bool, config_path: &Path) -> Result<(), String> {
+    if enabled {
+        ensure_unit(config_path)?;
+        run_systemctl(&["enable", UNIT_NAME], "failed to enable we-layerd at login")
+    } else {
+        let output = systemctl(&["disable", UNIT_NAME])?;
+        if !output.status.success() && !unit_missing(&output) {
+            return Err(output_error("failed to disable we-layerd at login", &output));
+        }
+        remove_managed_unit()
+    }
+}
+
+pub fn restart_if_active() -> Result<bool, String> {
+    if !is_active()? {
+        return Ok(false);
+    }
+    run_systemctl(&["restart", UNIT_NAME], "failed to restart systemd-managed we-layerd")?;
+    Ok(true)
+}
+
+fn is_active() -> Result<bool, String> {
+    let output = systemctl(&["is-active", UNIT_NAME])?;
+    if output.status.success() {
+        return Ok(true);
+    }
+    if unit_missing(&output) {
+        return Ok(false);
+    }
+
+    match stdout_state(&output).as_str() {
+        "inactive" | "failed" | "unknown" => Ok(false),
+        // These states still mean systemd owns the unit. Let systemd arbitrate the restart
+        // rather than replacing it with a GUI-owned process.
+        "activating" | "reloading" | "deactivating" => Ok(true),
+        _ => Err(output_error("failed to query systemd user service state", &output)),
+    }
+}
+
+fn ensure_unit(config_path: &Path) -> Result<(), String> {
+    let appimage = env::var_os("APPIMAGE").filter(|value| !value.is_empty()).map(PathBuf::from);
+    if appimage.is_none() && packaged_unit_available()? {
+        return Ok(());
+    }
+
+    let executable = match appimage {
+        Some(path) => Launcher::AppImage(path),
+        None => Launcher::Binary(super::runtime::layerd_executable().ok_or_else(|| {
+            "we-layerd executable was not found for systemd autostart".to_string()
+        })?),
+    };
+    let unit_path = generated_unit_path()?;
+    let unit = render_unit(&executable, config_path);
+    if fs::read_to_string(&unit_path).ok().as_deref() != Some(unit.as_str()) {
+        if let Some(parent) = unit_path.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                format!(
+                    "failed to create systemd user unit directory {}: {error}",
+                    parent.display()
+                )
+            })?;
+        }
+        fs::write(&unit_path, unit)
+            .map_err(|error| format!("failed to write {}: {error}", unit_path.display()))?;
+    }
+    run_systemctl(&["daemon-reload"], "failed to reload the systemd user manager")
+}
+
+fn packaged_unit_available() -> Result<bool, String> {
+    let output = systemctl(&["cat", UNIT_NAME])?;
+    if output.status.success() {
+        let unit = String::from_utf8_lossy(&output.stdout);
+        return Ok(!unit.contains(MANAGED_UNIT_MARKER));
+    }
+    if unit_missing(&output) {
+        return Ok(false);
+    }
+    Err(output_error("failed to inspect the systemd user unit", &output))
+}
+
+fn generated_unit_path() -> Result<PathBuf, String> {
+    let config_home = env::var_os("XDG_CONFIG_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".config")))
+        .ok_or_else(|| "HOME and XDG_CONFIG_HOME are both unavailable".to_string())?;
+    Ok(config_home.join("systemd/user").join(UNIT_NAME))
+}
+
+fn remove_managed_unit() -> Result<(), String> {
+    let path = generated_unit_path()?;
+    let Some(contents) = fs::read_to_string(&path).ok() else {
+        return Ok(());
+    };
+    if !contents.contains(MANAGED_UNIT_MARKER) {
+        return Ok(());
+    }
+    fs::remove_file(&path)
+        .map_err(|error| format!("failed to remove {}: {error}", path.display()))?;
+    run_systemctl(&["daemon-reload"], "failed to reload the systemd user manager")
+}
+
+#[derive(Debug)]
+enum Launcher {
+    Binary(PathBuf),
+    AppImage(PathBuf),
+}
+
+fn render_unit(launcher: &Launcher, config_path: &Path) -> String {
+    let executable = match launcher {
+        Launcher::Binary(path) => unit_quote(path),
+        Launcher::AppImage(path) => format!("{} --cli", unit_quote(path)),
+    };
+    format!(
+        "{MANAGED_UNIT_MARKER}\n[Unit]\nDescription=we-layerd wallpaper daemon\nPartOf=graphical-session.target\nAfter=graphical-session-pre.target\nConditionPathExists={}\n\n[Service]\nType=simple\nExecStart={executable} run --config {}\nRestart=on-failure\nRestartSec=2\n\n[Install]\nWantedBy=graphical-session.target\n",
+        unit_quote(config_path),
+        unit_quote(config_path),
+    )
+}
+
+fn unit_quote(path: &Path) -> String {
+    let value = path.to_string_lossy();
+    let escaped =
+        value.replace('\\', "\\\\").replace('"', "\\\"").replace('%', "%%").replace('$', "$$");
+    format!("\"{escaped}\"")
+}
+
+fn systemctl(args: &[&str]) -> Result<Output, String> {
+    Command::new("systemctl")
+        .arg("--user")
+        .args(args)
+        .output()
+        .map_err(|error| format!("failed to run systemctl --user: {error}"))
+}
+
+fn run_systemctl(args: &[&str], context: &str) -> Result<(), String> {
+    let output = systemctl(args)?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(output_error(context, &output))
+    }
+}
+
+fn stdout_state(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn unit_missing(output: &Output) -> bool {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    stdout.contains("not-found")
+        || stderr.contains("could not be found")
+        || stderr.contains("does not exist")
+        || stderr.contains("No files found")
+        || stderr.contains("not found")
+}
+
+fn output_error(context: &str, output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = stdout_state(output);
+    let detail = if !stderr.is_empty() { stderr } else { stdout };
+    if detail.is_empty() {
+        context.to_string()
+    } else {
+        format!("{context}: {detail}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{render_unit, unit_quote, Launcher, MANAGED_UNIT_MARKER};
+
+    #[test]
+    fn generated_appimage_unit_uses_cli_launcher_and_config() {
+        let unit = render_unit(
+            &Launcher::AppImage("/home/test/My Wallpapers.AppImage".into()),
+            Path::new("/home/test/.config/we-layerd/config.toml"),
+        );
+        assert!(unit.starts_with(MANAGED_UNIT_MARKER));
+        assert!(unit.contains(
+            "ExecStart=\"/home/test/My Wallpapers.AppImage\" --cli run --config \"/home/test/.config/we-layerd/config.toml\""
+        ));
+        assert!(unit.contains("PartOf=graphical-session.target"));
+        assert!(unit.contains("WantedBy=graphical-session.target"));
+    }
+
+    #[test]
+    fn generated_binary_unit_uses_resolved_daemon() {
+        let unit = render_unit(
+            &Launcher::Binary("/home/test/.local/bin/we-layerd".into()),
+            Path::new("/home/test/.config/we-layerd/config.toml"),
+        );
+        assert!(unit.contains(
+            "ExecStart=\"/home/test/.local/bin/we-layerd\" run --config \"/home/test/.config/we-layerd/config.toml\""
+        ));
+    }
+
+    #[test]
+    fn systemd_paths_escape_specifiers() {
+        assert_eq!(unit_quote(Path::new("/home/100%/$demo")), "\"/home/100%%/$$demo\"");
+    }
+}

--- a/apps/we-gui/src/services/mod.rs
+++ b/apps/we-gui/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod autostart;
 pub mod config;
 pub mod preferences;
 pub mod runtime;

--- a/apps/we-gui/src/services/runtime.rs
+++ b/apps/we-gui/src/services/runtime.rs
@@ -20,6 +20,10 @@ pub fn layerd_is_available() -> bool {
     resolve_layerd_executable().is_some()
 }
 
+pub fn layerd_executable() -> Option<PathBuf> {
+    resolve_layerd_executable()
+}
+
 pub fn try_switch(config_path: &Path) -> bool {
     let Ok(mut command) = layerd_command() else {
         return false;
@@ -64,12 +68,22 @@ pub fn start(config_path: &Path) -> std::io::Result<Child> {
     layerd_command()?.arg("run").arg("--config").arg(config_path).spawn()
 }
 
-pub fn restart(config_path: &Path, child: &mut Option<Child>) -> Result<Child, String> {
+pub fn restart(config_path: &Path, child: &mut Option<Child>) -> Result<Option<Child>, String> {
+    if child.is_none() {
+        match super::autostart::restart_if_active() {
+            Ok(true) => return Ok(None),
+            Ok(false) => {}
+            Err(error) => {
+                eprintln!("systemd ownership probe failed; using direct daemon fallback: {error}")
+            }
+        }
+    }
+
     let _ = stop(child);
 
     for _ in 0..40 {
         if !daemon_is_running() {
-            return start(config_path).map_err(|error| error.to_string());
+            return start(config_path).map(Some).map_err(|error| error.to_string());
         }
         std::thread::sleep(Duration::from_millis(50));
     }
@@ -133,6 +147,27 @@ pub fn stop(child: &mut Option<Child>) -> bool {
         stopped = true;
     }
     stopped || !daemon_is_running()
+}
+
+pub fn stop_owned(child: &mut Option<Child>) -> bool {
+    let Some(mut child) = child.take() else {
+        return true;
+    };
+
+    if child.try_wait().map_or(true, |status| status.is_some()) {
+        return true;
+    }
+
+    let _ = send_control("stop");
+    for _ in 0..3 {
+        if child.try_wait().map_or(true, |status| status.is_some()) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    true
 }
 
 pub fn daemon_is_running() -> bool {

--- a/apps/we-gui/src/ui/sidebar/settings.rs
+++ b/apps/we-gui/src/ui/sidebar/settings.rs
@@ -17,6 +17,9 @@ pub fn build_settings_overlay<'a>(
     ui_settings: &'a UiSettings,
     language: Language,
     runtime_status: &'a RuntimeStatus,
+    autostart_enabled: bool,
+    autostart_pending: bool,
+    autostart_error: Option<&'a str>,
 ) -> Element<'a, Message> {
     let assets_path_display = format_path_for_display(&ui_settings.assets_path, 64);
     let workshop_path_display = format_path_for_display(&ui_settings.workshop_path, 64);
@@ -40,8 +43,16 @@ pub fn build_settings_overlay<'a>(
         rule_options.iter().find(|option| option.value == ui_settings.rule_maximized).cloned();
     let selected_fullscreen_rule =
         rule_options.iter().find(|option| option.value == ui_settings.rule_fullscreen).cloned();
+    let autostart_checkbox = checkbox(autostart_enabled)
+        .label(language.text(Text::StartOnLogin))
+        .style(md_checkbox_style);
+    let autostart_checkbox = if autostart_pending {
+        autostart_checkbox
+    } else {
+        autostart_checkbox.on_toggle(Message::AutostartToggled)
+    };
 
-    let content = column![
+    let mut content = column![
         row![
             column![
                 text(language.text(Text::Settings)).size(26),
@@ -135,6 +146,8 @@ pub fn build_settings_overlay<'a>(
         )
         .id("settings.scale-mode"),
         section_title(language.text(Text::Behaviour)),
+        container(autostart_checkbox).id("settings.autostart"),
+        text(language.text(Text::StartOnLoginDescription)).size(12),
         container(
             checkbox(ui_settings.interactive)
                 .label(language.text(Text::EnableWallpaperInput))
@@ -245,6 +258,9 @@ pub fn build_settings_overlay<'a>(
             .style(status_box_style),
     ]
     .spacing(10);
+    if let Some(error) = autostart_error {
+        content = content.push(text(error).size(12));
+    }
 
     container(
         scrollable(container(content).padding(iced::Padding {

--- a/contrib/systemd/we-layerd.service
+++ b/contrib/systemd/we-layerd.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=we-layerd wallpaper daemon
+PartOf=graphical-session.target
+After=graphical-session-pre.target
+ConditionPathExists=%h/.config/we-layerd/config.toml
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/we-layerd run --config %h/.config/we-layerd/config.toml
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=graphical-session.target

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -6,6 +6,27 @@
 - File-socket fallback is kept for compatibility.
 - Daemon startup acquires an instance lock; launching a second instance under the same user returns an `already running` error.
 
+## Start on Login
+
+Native packages install `we-layerd.service` as a systemd user service. Enable it for future
+graphical logins with:
+
+```bash
+systemctl --user enable we-layerd.service
+```
+
+If no daemon is currently running and you also want to start it in the current session, run
+`systemctl --user start we-layerd.service`.
+
+The service loads `~/.config/we-layerd/config.toml`, so the wallpaper and output bindings last saved
+by `we-gui` are restored at the next graphical login. The GUI exposes the same enable/disable state
+as **Settings → Behaviour → Start wallpaper on login**. AppImage and local-binary launches create a
+user unit under `~/.config/systemd/user/` when that setting is enabled.
+
+Closing `we-gui` does not stop a daemon that was already running under systemd or another external
+owner. A fallback daemon spawned directly by the GUI remains GUI-owned and is cleaned up with the
+GUI. The explicit **Stop** action still stops the current daemon regardless of ownership.
+
 ## Runtime Control
 
 Control a running daemon:

--- a/docs/ADVANCED.zh-CN.md
+++ b/docs/ADVANCED.zh-CN.md
@@ -6,6 +6,27 @@
 - 同时保留文件 socket 回退逻辑以兼容更多环境。
 - 守护进程启动时会获取单实例锁；同一用户重复启动会返回 `already running`。
 
+## 登录时自动启动
+
+原生软件包会安装 systemd 用户服务 `we-layerd.service`。要让它在后续图形会话登录时
+自动启动，可以执行：
+
+```bash
+systemctl --user enable we-layerd.service
+```
+
+如果当前没有 daemon 正在运行，并且希望本次会话立即启动，再执行
+`systemctl --user start we-layerd.service`。
+
+服务会读取 `~/.config/we-layerd/config.toml`，因此 `we-gui` 最近保存的壁纸与输出绑定会在
+下一次图形会话登录时自动恢复。GUI 中的 **设置 → 行为 → 登录时自动启动壁纸** 管理同一个
+enable/disable 状态。AppImage 或本地二进制没有随包 unit 时，启用该设置会在
+`~/.config/systemd/user/` 下生成当前启动器对应的用户 unit。
+
+关闭 `we-gui` 不会停止已经由 systemd 或其他外部 owner 启动的守护进程；只有 GUI 自己
+直接拉起的 fallback 子进程会随 GUI 回收。显式的 **停止** 操作仍会停止当前守护进程，
+不区分 owner。
+
 ## 运行时控制
 
 控制运行中的守护进程：

--- a/package/archlinux/PKGBUILD
+++ b/package/archlinux/PKGBUILD
@@ -78,6 +78,8 @@ package() {
   install -Dm755 target/release/we-gui "${pkgdir}/usr/bin/we-gui"
   install -Dm644 apps/we-gui/assets/we-gui.desktop \
     "${pkgdir}/usr/share/applications/we-gui.desktop"
+  install -Dm644 contrib/systemd/we-layerd.service \
+    "${pkgdir}/usr/lib/systemd/user/we-layerd.service"
   install -Dm755 \
     target/we-renderer-upstream/install/lib/libwallpaper-engine-renderer.so \
     "${pkgdir}/usr/lib/libwallpaper-engine-renderer.so"

--- a/package/fedora/we-layerd.spec
+++ b/package/fedora/we-layerd.spec
@@ -97,6 +97,8 @@ install -Dm0644 apps/we-gui/assets/we-gui.desktop \
   %{buildroot}%{_datadir}/applications/we-gui.desktop
 install -Dm0644 apps/we-gui/assets/we-gui-logo.svg \
   %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/we-gui.svg
+install -Dm0644 contrib/systemd/we-layerd.service \
+  %{buildroot}%{_prefix}/lib/systemd/user/we-layerd.service
 
 desktop-file-validate %{buildroot}%{_datadir}/applications/we-gui.desktop
 
@@ -129,6 +131,7 @@ readelf -d %{buildroot}%{_prefix}/lib/libwallpaper-engine-renderer.so \
 %{_datadir}/applications/we-gui.desktop
 %{_datadir}/icons/hicolor/scalable/apps/we-gui.svg
 %{_datadir}/gnome-shell/extensions/we-layerd@aromatic/
+%{_prefix}/lib/systemd/user/we-layerd.service
 %license %{_licensedir}/%{name}/DXC-LICENSE-MS.txt
 %license %{_licensedir}/%{name}/DXC-LICENSE-LLVM.txt
 

--- a/package/ubuntu/debian/rules
+++ b/package/ubuntu/debian/rules
@@ -65,6 +65,8 @@ override_dh_auto_install:
 		$(PACKAGE_ROOT)/usr/share/applications/we-gui.desktop
 	install -Dm0644 apps/we-gui/assets/we-gui-logo.svg \
 		$(PACKAGE_ROOT)/usr/share/icons/hicolor/scalable/apps/we-gui.svg
+	install -Dm0644 contrib/systemd/we-layerd.service \
+		$(PACKAGE_ROOT)/usr/lib/systemd/user/we-layerd.service
 
 	install -d $(PRIVATE_LIB)/we-layerd/dxc
 	install -m0755 $(DXC_ROOT)/lib/libdxcompiler.so \


### PR DESCRIPTION
## Summary

- add a systemd user service for persistent wallpaper startup at login
- add a GUI setting to enable or disable login autostart
- keep externally owned/systemd-owned wallpaper daemons running when the GUI exits
- only clean up daemon processes directly spawned and owned by the GUI
- preserve systemd ownership when the GUI restarts an active service
- install the user service in Arch, Fedora, and Ubuntu packages
- update the renderer submodule with the stable system-CEF API fix

## Behavior

`Quit GUI` no longer means `Stop wallpaper`. The explicit Stop action still stops the daemon globally.

This implements the systemd-user-service design discussed in #31 and supersedes the narrower lifecycle-only approach in #36.

## Validation

- `cargo test -p we-gui`: 46 passed
- `cargo clippy -p we-gui -- -D warnings`: passed
- native renderer rebuilt against stable CEF API 13300
- systemd service tested with the configured web wallpaper: active/running, NRestarts=0, no CEF API hash mismatch