### PR TITLE
perf(layer-shell): integrate DMA-BUF buffer reuse

### DIFF
--- a/crates/we-renderer-sys/src/lib.rs
+++ b/crates/we-renderer-sys/src/lib.rs
@@ -13,6 +13,9 @@ pub const WE_RENDER_CONFIG_V1_VERSION: u32 = 1;
 pub const WE_RUNTIME_SETTINGS_V1_VERSION: u32 = 1;
 pub const WE_MEDIA_STATE_V1_VERSION: u32 = 1;
 pub const WE_FRAME_V1_VERSION: u32 = 1;
+pub const WE_FRAME_FLAG_PREMULTIPLIED: u32 = 1 << 0;
+pub const WE_FRAME_FLAG_FDS_OMITTED: u32 = 1 << 1;
+pub const WE_FRAME_BUFFER_ID_INVALID: u32 = u32::MAX;
 pub const WE_INPUT_EVENT_V2_VERSION: u32 = 2;
 
 #[repr(C)]
@@ -97,6 +100,8 @@ pub struct we_frame_v1 {
     pub shm_stride: u32,
     pub shm_size: u32,
     pub planes: [we_dmabuf_plane_v1; 4],
+    pub buffer_id: u32,
+    pub reusable_buffer_mask: u32,
 }
 
 #[repr(C)]
@@ -514,10 +519,12 @@ mod tests {
         assert_eq!(offset_of!(we_media_state_v1, thumbnail_rgba), 144);
         assert_eq!(offset_of!(we_media_state_v1, previous_thumbnail_rgba), 160);
 
-        assert_eq!(size_of::<we_frame_v1>(), 112);
+        assert_eq!(size_of::<we_frame_v1>(), 120);
         assert_eq!(align_of::<we_frame_v1>(), 8);
         assert_eq!(offset_of!(we_frame_v1, kind), 8);
         assert_eq!(offset_of!(we_frame_v1, planes), 64);
+        assert_eq!(offset_of!(we_frame_v1, buffer_id), 112);
+        assert_eq!(offset_of!(we_frame_v1, reusable_buffer_mask), 116);
 
         assert_eq!(size_of::<we_input_event_v2>(), 52);
         assert_eq!(align_of::<we_input_event_v2>(), 4);

--- a/crates/we-renderer/src/lib.rs
+++ b/crates/we-renderer/src/lib.rs
@@ -171,6 +171,8 @@ pub struct DmabufFrame {
     pub flags: u32,
     pub serial: u64,
     pub pts_ns: u64,
+    pub buffer_id: Option<u32>,
+    pub fds_omitted: bool,
     pub planes: Vec<DmabufPlane>,
 }
 
@@ -474,6 +476,13 @@ impl Session {
     }
 
     pub fn acquire_frame(&mut self) -> Result<Option<Frame>, Error> {
+        self.acquire_frame_with_reusable_buffers(0)
+    }
+
+    pub fn acquire_frame_with_reusable_buffers(
+        &mut self,
+        reusable_buffer_mask: u32,
+    ) -> Result<Option<Frame>, Error> {
         let mut raw = sys::we_frame_v1 {
             size: std::mem::size_of::<sys::we_frame_v1>() as u32,
             version: sys::WE_FRAME_V1_VERSION,
@@ -489,6 +498,8 @@ impl Session {
             shm_stride: 0,
             shm_size: 0,
             planes: [sys::we_dmabuf_plane_v1 { fd: -1, offset: 0, stride: 0 }; 4],
+            buffer_id: sys::WE_FRAME_BUFFER_ID_INVALID,
+            reusable_buffer_mask,
         };
 
         let status = unsafe { self.library.session_acquire_frame(self.raw, &mut raw) };
@@ -752,13 +763,16 @@ fn frame_from_raw(raw: &sys::we_frame_v1) -> Result<Frame, Error> {
             if raw.n_planes > raw.planes.len() as u32 {
                 return Err(Error::InvalidPlaneCount(raw.n_planes));
             }
+            let fds_omitted = raw.flags & sys::WE_FRAME_FLAG_FDS_OMITTED != 0;
             let mut planes = Vec::with_capacity(raw.n_planes as usize);
-            for plane in raw.planes.iter().take(raw.n_planes as usize) {
-                planes.push(DmabufPlane {
-                    fd: duplicate_fd(plane.fd)?,
-                    offset: plane.offset,
-                    stride: plane.stride,
-                });
+            if !fds_omitted {
+                for plane in raw.planes.iter().take(raw.n_planes as usize) {
+                    planes.push(DmabufPlane {
+                        fd: duplicate_fd(plane.fd)?,
+                        offset: plane.offset,
+                        stride: plane.stride,
+                    });
+                }
             }
             Ok(Frame::Dmabuf(DmabufFrame {
                 width: raw.width,
@@ -768,6 +782,9 @@ fn frame_from_raw(raw: &sys::we_frame_v1) -> Result<Frame, Error> {
                 flags: raw.flags,
                 serial: raw.serial,
                 pts_ns: raw.pts_ns,
+                buffer_id: (raw.buffer_id != sys::WE_FRAME_BUFFER_ID_INVALID)
+                    .then_some(raw.buffer_id),
+                fds_omitted,
                 planes,
             }))
         }
@@ -829,10 +846,42 @@ mod tests {
             shm_stride: 0,
             shm_size: 0,
             planes: [we_dmabuf_plane_v1 { fd: -1, offset: 0, stride: 0 }; 4],
+            buffer_id: u32::MAX,
+            reusable_buffer_mask: 0,
         };
 
         let err = frame_from_raw(&raw).expect_err("too many planes should fail");
         assert!(err.to_string().contains("exceeds the ABI limit"));
+    }
+
+    #[test]
+    fn dmabuf_frame_conversion_accepts_omitted_reusable_fds() {
+        let raw = we_frame_v1 {
+            size: std::mem::size_of::<we_frame_v1>() as u32,
+            version: 1,
+            kind: we_frame_kind_v1::WE_FRAME_KIND_DMABUF as u32,
+            width: 1920,
+            height: 1080,
+            drm_fourcc: u32::from_le_bytes(*b"AB24"),
+            drm_modifier: 0,
+            n_planes: 1,
+            flags: we_renderer_sys::WE_FRAME_FLAG_FDS_OMITTED,
+            serial: 2,
+            pts_ns: 0,
+            shm_stride: 0,
+            shm_size: 0,
+            planes: [we_dmabuf_plane_v1 { fd: -1, offset: 0, stride: 7680 }; 4],
+            buffer_id: 2,
+            reusable_buffer_mask: 0,
+        };
+
+        let frame = frame_from_raw(&raw).expect("reusable DMA-BUF metadata should be valid");
+        let Frame::Dmabuf(frame) = frame else {
+            panic!("expected DMA-BUF frame");
+        };
+        assert_eq!(frame.buffer_id, Some(2));
+        assert!(frame.fds_omitted);
+        assert!(frame.planes.is_empty());
     }
 
     #[test]
@@ -858,6 +907,8 @@ mod tests {
                 we_dmabuf_plane_v1 { fd: -1, offset: 0, stride: 0 },
                 we_dmabuf_plane_v1 { fd: -1, offset: 0, stride: 0 },
             ],
+            buffer_id: u32::MAX,
+            reusable_buffer_mask: 0,
         };
 
         let frame = frame_from_raw(&raw).expect("valid shm frame");
@@ -888,6 +939,8 @@ mod tests {
             shm_stride: 0,
             shm_size: 0,
             planes: [we_dmabuf_plane_v1 { fd: -1, offset: 0, stride: 0 }; 4],
+            buffer_id: u32::MAX,
+            reusable_buffer_mask: 0,
         };
 
         let err = frame_from_raw(&raw).expect_err("unknown kind should fail");

--- a/src/backend/layer_shell/event_loop.rs
+++ b/src/backend/layer_shell/event_loop.rs
@@ -56,6 +56,10 @@ fn note_frame_acquired(state: &mut LayerShellState, frame: &Frame) {
             state.frame_stats.last_present_backend = Some(PresentBackend::Dmabuf);
             state.frame_stats.last_frame_width = dmabuf.width;
             state.frame_stats.last_frame_height = dmabuf.height;
+            if dmabuf.fds_omitted {
+                state.frame_stats.dmabuf_fdless_acquires =
+                    state.frame_stats.dmabuf_fdless_acquires.saturating_add(1);
+            }
         }
         Frame::Shm(shm) => {
             state.frame_stats.last_present_backend = Some(PresentBackend::Shm);
@@ -621,6 +625,9 @@ pub(crate) fn run_output(ctx: BackendContext<'_>, target_output: &str) -> Result
                 presented = state.frame_stats.presented,
                 no_frame_polls = state.frame_stats.no_frame_polls,
                 in_flight = state.frame_stats.in_flight_count,
+                wayland_buffers_created = state.frame_stats.wayland_buffers_created,
+                wayland_buffers_reused = state.frame_stats.wayland_buffers_reused,
+                dmabuf_fdless_acquires = state.frame_stats.dmabuf_fdless_acquires,
                 last_present_backend = state
                     .frame_stats
                     .last_present_backend
@@ -705,8 +712,9 @@ pub(crate) fn run_output(ctx: BackendContext<'_>, target_output: &str) -> Result
         }
 
         if (poll_fds[1].revents & libc::POLLIN) != 0 && can_present_next_frame(&state) {
+            let reusable_buffer_mask = state.reusable_buffer_mask();
             if let Some(ref mut session) = state.session {
-                match session.acquire_frame()? {
+                match session.acquire_frame(reusable_buffer_mask)? {
                     Some(frame) => {
                         note_frame_acquired(&mut state, &frame);
                         presenter::present_frame(&mut state, &qh, frame)

--- a/src/backend/layer_shell/state.rs
+++ b/src/backend/layer_shell/state.rs
@@ -34,6 +34,27 @@ use crate::{
 
 pub(super) const MAX_IN_FLIGHT_BUFFERS: usize = 3;
 
+// DMA-BUF file descriptors are duplicated by the renderer ABI on every frame.
+// Their (device, inode) identity remains stable across dup() calls, so it can
+// identify the underlying exported image without extending the renderer ABI.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct DmabufPlaneKey {
+    pub(super) device: u64,
+    pub(super) inode: u64,
+    pub(super) offset: u32,
+    pub(super) stride: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct DmabufKey {
+    pub(super) width: u32,
+    pub(super) height: u32,
+    pub(super) drm_fourcc: u32,
+    pub(super) drm_modifier: u64,
+    pub(super) plane_count: u32,
+    pub(super) planes: [DmabufPlaneKey; 4],
+}
+
 // ---------------------------------------------------------------------------
 // Buffer bookkeeping
 // ---------------------------------------------------------------------------
@@ -43,6 +64,9 @@ pub(super) struct WaylandBuffer {
     pub(super) buffer: WlBuffer,
     pub(super) released: Arc<AtomicBool>,
     pub(super) pending_fds: Vec<OwnedFd>,
+    pub(super) dmabuf_key: Option<DmabufKey>,
+    pub(super) buffer_id: Option<u32>,
+    pub(super) generation: u64,
 }
 
 impl Drop for WaylandBuffer {
@@ -76,12 +100,19 @@ pub(super) struct FrameCallbackState {
 
 pub(super) struct BufferBookkeeping {
     pub(super) in_flight: Vec<WaylandBuffer>,
+    pub(super) reusable: Vec<WaylandBuffer>,
     pub(super) max_in_flight: usize,
+    pub(super) generation: u64,
 }
 
 impl Default for BufferBookkeeping {
     fn default() -> Self {
-        Self { in_flight: Vec::new(), max_in_flight: MAX_IN_FLIGHT_BUFFERS }
+        Self {
+            in_flight: Vec::new(),
+            reusable: Vec::new(),
+            max_in_flight: MAX_IN_FLIGHT_BUFFERS,
+            generation: 0,
+        }
     }
 }
 
@@ -124,10 +155,19 @@ impl LayerShellState {
         self.output.recompute_geometry();
         let new_size = (self.output.geometry.render_width, self.output.geometry.render_height);
         if self.render_resolution_follows_output && old_size != new_size {
-            if let Some(session) = &mut self.session {
-                if let Err(error) = session.resize_output(new_size.0, new_size.1) {
-                    tracing::warn!(%error, width = new_size.0, height = new_size.1, "failed to resize renderer output");
+            let resized = if let Some(session) = &mut self.session {
+                match session.resize_output(new_size.0, new_size.1) {
+                    Ok(()) => true,
+                    Err(error) => {
+                        tracing::warn!(%error, width = new_size.0, height = new_size.1, "failed to resize renderer output");
+                        false
+                    }
                 }
+            } else {
+                false
+            };
+            if resized {
+                self.invalidate_reusable();
             }
         }
     }
@@ -283,12 +323,41 @@ impl LayerShellState {
         }
     }
 
+    pub(super) fn reusable_buffer_mask(&self) -> u32 {
+        self.buffers.reusable.iter().fold(0, |mask, entry| match entry.buffer_id {
+            Some(id) if id < u32::BITS => mask | (1u32 << id),
+            _ => mask,
+        })
+    }
+
+    pub(super) fn invalidate_reusable(&mut self) {
+        self.buffers.reusable.clear();
+        self.buffers.generation = self.buffers.generation.saturating_add(1);
+    }
+
     pub(super) fn collect_released_buffers(&mut self) {
-        let before = self.buffers.in_flight.len();
-        self.buffers.in_flight.retain(|entry| {
-            !(entry.pending_fds.is_empty() && entry.released.load(Ordering::SeqCst))
-        });
-        let released = before.saturating_sub(self.buffers.in_flight.len());
+        let in_flight = std::mem::take(&mut self.buffers.in_flight);
+        let mut released = 0usize;
+        for entry in in_flight {
+            if entry.pending_fds.is_empty() && entry.released.load(Ordering::SeqCst) {
+                // SHM buffers still use the old create-per-frame lifecycle. Only
+                // retain DMA-BUF wl_buffers for a later attach, and never carry
+                // an old renderer generation across a resize/format change.
+                if entry.generation == self.buffers.generation
+                    && (entry.dmabuf_key.is_some() || entry.buffer_id.is_some())
+                {
+                    // Keep the cache bounded if the output is resized or its
+                    // format changes while old buffers are still draining.
+                    if self.buffers.reusable.len() >= MAX_IN_FLIGHT_BUFFERS {
+                        self.buffers.reusable.swap_remove(0);
+                    }
+                    self.buffers.reusable.push(entry);
+                }
+                released += 1;
+            } else {
+                self.buffers.in_flight.push(entry);
+            }
+        }
         self.frame_stats.released_buffers =
             self.frame_stats.released_buffers.saturating_add(released as u64);
         self.frame_stats.in_flight_count = self.buffers.in_flight.len();
@@ -296,6 +365,7 @@ impl LayerShellState {
 
     pub(super) fn clear_in_flight_buffers(&mut self) {
         self.buffers.in_flight.clear();
+        self.buffers.reusable.clear();
         self.frame_stats.in_flight_count = 0;
     }
 

--- a/src/backend/layer_shell/surface.rs
+++ b/src/backend/layer_shell/surface.rs
@@ -1,4 +1,4 @@
-use std::os::fd::{AsFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 
 use anyhow::{anyhow, Result};
 use wayland_client::{
@@ -33,10 +33,10 @@ use wayland_protocols_wlr::layer_shell::v1::client::{
     zwlr_layer_shell_v1::ZwlrLayerShellV1,
     zwlr_layer_surface_v1::{Event as LayerSurfaceEvent, ZwlrLayerSurfaceV1},
 };
-use we_renderer::Frame;
+use we_renderer::{DmabufFrame, Frame};
 
 use crate::backend::{
-    layer_shell::state::{LayerShellState, WaylandBuffer},
+    layer_shell::state::{DmabufKey, DmabufPlaneKey, LayerShellState, WaylandBuffer},
     wayland_common::{input::PointerAxis, output::FRACTIONAL_SCALE_DENOMINATOR},
 };
 
@@ -54,6 +54,38 @@ fn to_opaque_drm_fourcc(fourcc: u32) -> u32 {
         DRM_FORMAT_ARGB8888 => DRM_FORMAT_XRGB8888,
         _ => fourcc,
     }
+}
+
+fn dma_buf_fd_identity(fd: &OwnedFd) -> Option<(u64, u64)> {
+    let mut metadata = std::mem::MaybeUninit::<libc::stat>::uninit();
+    let result = unsafe { libc::fstat(fd.as_raw_fd(), metadata.as_mut_ptr()) };
+    if result != 0 {
+        return None;
+    }
+    let metadata = unsafe { metadata.assume_init() };
+    Some((metadata.st_dev, metadata.st_ino))
+}
+
+fn dmabuf_key(frame: &DmabufFrame) -> Option<DmabufKey> {
+    if frame.planes.is_empty() || frame.planes.len() > 4 {
+        return None;
+    }
+
+    let mut planes = [DmabufPlaneKey::default(); 4];
+    for (index, plane) in frame.planes.iter().enumerate() {
+        let (device, inode) = dma_buf_fd_identity(&plane.fd)?;
+        planes[index] =
+            DmabufPlaneKey { device, inode, offset: plane.offset, stride: plane.stride };
+    }
+
+    Some(DmabufKey {
+        width: frame.width,
+        height: frame.height,
+        drm_fourcc: frame.drm_fourcc,
+        drm_modifier: frame.drm_modifier,
+        plane_count: frame.planes.len() as u32,
+        planes,
+    })
 }
 
 fn release_wayland_pointer(pointer: WlPointer) {
@@ -128,13 +160,21 @@ impl Dispatch<ZwpLinuxDmabufFeedbackV1, ()> for LayerShellState {
                 let formats = state.dmabuf_feedback.finish_surface_feedback();
                 state.diagnostics.dmabuf_formats_known = true;
                 state.diagnostics.dmabuf_format_count = formats.len();
-                if let Some(session) = &mut state.session {
+                if state.session.is_some() {
                     let pairs: Vec<(u32, u64)> =
                         formats.iter().map(|format| (format.fourcc, format.modifier)).collect();
-                    if let Err(error) = session.set_dmabuf_formats(&pairs) {
-                        tracing::error!(%error, "failed to apply updated DMA-BUF feedback");
-                        state.frame_stats.last_error = Some(error.to_string());
-                        state.running = false;
+                    let applied = state
+                        .session
+                        .as_mut()
+                        .expect("session checked above")
+                        .set_dmabuf_formats(&pairs);
+                    match applied {
+                        Ok(()) => state.invalidate_reusable(),
+                        Err(error) => {
+                            tracing::error!(%error, "failed to apply updated DMA-BUF feedback");
+                            state.frame_stats.last_error = Some(error.to_string());
+                            state.running = false;
+                        }
                     }
                 }
             }
@@ -387,7 +427,7 @@ delegate_noop!(
 // ---------------------------------------------------------------------------
 
 pub(super) fn create_buffer_for_frame(
-    state: &LayerShellState,
+    state: &mut LayerShellState,
     qh: &QueueHandle<LayerShellState>,
     frame: Frame,
 ) -> Result<WaylandBuffer> {
@@ -407,9 +447,52 @@ pub(super) fn create_buffer_for_frame(
                 std::sync::Arc::clone(&released),
             );
             pool.destroy();
-            Ok(WaylandBuffer { buffer, released, pending_fds: vec![shm.fd] })
+            state.frame_stats.wayland_buffers_created =
+                state.frame_stats.wayland_buffers_created.saturating_add(1);
+            Ok(WaylandBuffer {
+                buffer,
+                released,
+                pending_fds: vec![shm.fd],
+                dmabuf_key: None,
+                buffer_id: None,
+                generation: state.buffers.generation,
+            })
         }
         Frame::Dmabuf(dmabuf) => {
+            let reuse_key = dmabuf_key(&dmabuf);
+            let reusable_index = dmabuf
+                .buffer_id
+                .and_then(|buffer_id| {
+                    state
+                        .buffers
+                        .reusable
+                        .iter()
+                        .position(|entry| entry.buffer_id == Some(buffer_id))
+                })
+                .or_else(|| {
+                    reuse_key.and_then(|key| {
+                        state
+                            .buffers
+                            .reusable
+                            .iter()
+                            .position(|entry| entry.dmabuf_key == Some(key))
+                    })
+                });
+            if let Some(index) = reusable_index {
+                let mut entry = state.buffers.reusable.swap_remove(index);
+                entry.pending_fds.clear();
+                entry.released.store(false, std::sync::atomic::Ordering::SeqCst);
+                state.frame_stats.wayland_buffers_reused =
+                    state.frame_stats.wayland_buffers_reused.saturating_add(1);
+                return Ok(entry);
+            }
+            if dmabuf.fds_omitted {
+                return Err(anyhow!(
+                    "renderer omitted DMA-BUF fds for unavailable buffer {}",
+                    dmabuf.buffer_id.unwrap_or(u32::MAX)
+                ));
+            }
+
             let dmabuf_obj = state
                 .objects
                 .dmabuf
@@ -439,7 +522,16 @@ pub(super) fn create_buffer_for_frame(
             );
             params.destroy();
             let pending_fds: Vec<OwnedFd> = dmabuf.planes.into_iter().map(|p| p.fd).collect();
-            Ok(WaylandBuffer { buffer, released, pending_fds })
+            state.frame_stats.wayland_buffers_created =
+                state.frame_stats.wayland_buffers_created.saturating_add(1);
+            Ok(WaylandBuffer {
+                buffer,
+                released,
+                pending_fds,
+                dmabuf_key: reuse_key,
+                buffer_id: dmabuf.buffer_id,
+                generation: state.buffers.generation,
+            })
         }
     }
 }

--- a/src/runtime/renderer_session.rs
+++ b/src/runtime/renderer_session.rs
@@ -99,8 +99,10 @@ impl RendererSession {
         self.session.tick().context("renderer tick failed")
     }
 
-    pub(crate) fn acquire_frame(&mut self) -> Result<Option<Frame>> {
-        self.session.acquire_frame().context("failed to acquire frame")
+    pub(crate) fn acquire_frame(&mut self, reusable_buffer_mask: u32) -> Result<Option<Frame>> {
+        self.session
+            .acquire_frame_with_reusable_buffers(reusable_buffer_mask)
+            .context("failed to acquire frame")
     }
 
     pub(crate) fn diagnostics(&self) -> Result<RendererDiagnostics> {

--- a/src/runtime/status.rs
+++ b/src/runtime/status.rs
@@ -54,6 +54,9 @@ pub(crate) struct FrameStats {
     pub(crate) skipped_by_backpressure: u64,
     pub(crate) no_frame_polls: u64,
     pub(crate) released_buffers: u64,
+    pub(crate) wayland_buffers_created: u64,
+    pub(crate) wayland_buffers_reused: u64,
+    pub(crate) dmabuf_fdless_acquires: u64,
     pub(crate) in_flight_count: usize,
     pub(crate) last_present_backend: Option<PresentBackend>,
     pub(crate) last_frame_width: u32,
@@ -236,6 +239,9 @@ impl RuntimeStatusSnapshot {
             format!("skipped_by_backpressure = {}", self.frame_stats.skipped_by_backpressure),
             format!("no_frame_polls = {}", self.frame_stats.no_frame_polls),
             format!("released_buffers = {}", self.frame_stats.released_buffers),
+            format!("wayland_buffers_created = {}", self.frame_stats.wayland_buffers_created),
+            format!("wayland_buffers_reused = {}", self.frame_stats.wayland_buffers_reused),
+            format!("dmabuf_fdless_acquires = {}", self.frame_stats.dmabuf_fdless_acquires),
             format!("last_error = {:?}", self.frame_stats.last_error.as_deref().unwrap_or("")),
         ]);
 


### PR DESCRIPTION
## Summary

Integrate the DMA-BUF `wl_buffer` reuse work from #40 onto current `main` after landing the renderer ABI support canonically in Aromatic05/wallpaper-engine-renderer#6.

This preserves #40's original commit as the second parent of the integration merge commit while resolving the stale submodule conflict locally.

Changes:
- reuse released DMA-BUF `wl_buffer` objects for stable renderer swapchain slots;
- request descriptor-free frame acquisition only for buffers that are actually reusable;
- keep SHM on its existing create-per-frame lifecycle;
- invalidate reusable buffers on generation-changing renderer resize/format feedback;
- bound the reusable cache to the three-buffer swapchain size;
- update the renderer gitlink to canonical merge `89dfcd86` from renderer PR #6;
- add focused state-machine coverage for generation invalidation, cache bounds, stable buffer IDs, DMA-BUF identity fallback, and rejecting fdless frames without a reusable match.

## Validation

Local only; no GitHub Actions were used intentionally.

- `cargo test --workspace` — pass
- focused layer-shell tests — 29/29 pass
- `we-renderer` — 9/9 pass
- `we-renderer-sys` — 2/2 pass
- `cargo build -p we-layerd` — pass
- clippy with `-D warnings` — pass
- `git diff --check` — pass

Supersedes #40.